### PR TITLE
Add keep_sparse option for TextModule.batch_bow()

### DIFF
--- a/cornac/data/text.py
+++ b/cornac/data/text.py
@@ -539,8 +539,21 @@ class TextModule(FeatureModule):
 
         return seq_mat
 
-    def batch_bow(self, batch_ids, binary=False):
+    def batch_bow(self, batch_ids, binary=False, keep_sparse=False):
         """Return matrix of bag-of-words corresponding to provided batch_ids
+
+        Parameters
+        ----------
+        batch_ids: array
+            An array of ids to retrieve the corresponding features.
+
+        binary: bool, default = False
+            If `True`, the feature values will be converted into (0 or 1).
+
+        keep_sparse: bool, default = False
+            If `True`, the return feature matrix will be a `scipy.sparse.csr_matrix`.
+            Otherwise, it will be a dense matrix.
+
         """
         if self.count_matrix is None:
             raise ValueError('self.counts is required but None!')
@@ -549,7 +562,10 @@ class TextModule(FeatureModule):
         if binary:
             bow_mat.data.fill(1)
 
-        return bow_mat
+        if keep_sparse:
+            return bow_mat
+
+        return bow_mat.A
 
     def batch_tfidf(self, batch_ids):
         """Return matrix of TF-IDF features corresponding to provided batch_ids

--- a/tests/cornac/data/test_text.py
+++ b/tests/cornac/data/test_text.py
@@ -220,7 +220,7 @@ class TestTextModule(unittest.TestCase):
 
         batch_bows = self.module.batch_bow([2, 1])
         self.assertEqual((2, self.module.max_vocab), batch_bows.shape)
-        expected_bows = np.zeros_like(batch_bows.A)
+        expected_bows = np.zeros_like(batch_bows)
         expected_bows[0, b - shift] = 1
         expected_bows[0, c - shift] = 2
         expected_bows[0, e - shift] = 1
@@ -228,9 +228,9 @@ class TestTextModule(unittest.TestCase):
         expected_bows[1, b - shift] = 1
         expected_bows[1, c - shift] = 1
         expected_bows[1, d - shift] = 2
-        npt.assert_array_equal(batch_bows.A, expected_bows)
+        npt.assert_array_equal(batch_bows, expected_bows)
 
-        batch_bows = self.module.batch_bow([0, 2], binary=True)
+        batch_bows = self.module.batch_bow([0, 2], binary=True, keep_sparse=True)
         self.assertEqual((2, 6), batch_bows.shape)
         expected_bows = np.zeros_like(batch_bows.A)
         expected_bows[0, np.asarray([a, b, c]) - shift] = 1


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
Add keep_sparse option for TextModule.batch_bow()


### Related Issues


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added tests.
- [ ] I have updated the documentation accordingly.