### PR TITLE
Support more types of archive in download utils 

### DIFF
--- a/tests/cornac/data/test_reader.py
+++ b/tests/cornac/data/test_reader.py
@@ -15,11 +15,20 @@ class TestReader(unittest.TestCase):
         self.data_file = './tests/data.txt'
         self.reader = Reader()
 
+    def test_raise(self):
+        try:
+            self.reader.read(self.data_file, fmt='bla bla')
+        except ValueError:
+            assert True
+
     def test_read_ui(self):
         triplets = self.reader.read(self.data_file, fmt='UI')
         self.assertEqual(len(triplets), 30)
         self.assertEqual(triplets[0][1], '93')
         self.assertEqual(triplets[1][2], 1.0)
+
+        triplets = self.reader.read(self.data_file, fmt='UI', id_inline=True)
+        self.assertEqual(len(triplets), 40)
 
     def test_read_uir(self):
         triplet_data = self.reader.read(self.data_file)

--- a/tests/cornac/utils/test_download.py
+++ b/tests/cornac/utils/test_download.py
@@ -12,19 +12,33 @@ from cornac.utils.download import cache
 class TestDownload(unittest.TestCase):
 
     def test_download_normal_file(self):
-        fpath = cache(url='https://static.preferred.ai/cornac/hello_world.txt')
+        fpath = cache(url='https://static.preferred.ai/cornac/tests/hello_world.txt')
         self.assertTrue(os.path.exists(fpath))
         with open(fpath, 'r') as f:
             self.assertEqual("I'm Cornac!", f.read().strip())
 
-        cache(url='https://static.preferred.ai/cornac/hello_world.txt')
+        cache(url='https://static.preferred.ai/cornac/tests/hello_world.txt')
 
     def test_download_zip_file(self):
-        fpath = cache(url='https://static.preferred.ai/cornac/dummy.zip',
+        fpath = cache(url='https://static.preferred.ai/cornac/tests/dummy.zip',
                       unzip=True, relative_path='dummy/hello_world.txt')
         self.assertTrue(os.path.exists(fpath))
         with open(fpath, 'r') as f:
             self.assertEqual("I'm Cornac!", f.read().strip())
+
+    def test_download_gzip_file(self):
+        fpath = cache(url='https://static.preferred.ai/cornac/tests/dummy.tar.gz',
+                      unzip=True, relative_path='dummy/gz.txt')
+        self.assertTrue(os.path.exists(fpath))
+        with open(fpath, 'r') as f:
+            self.assertEqual('gz', f.read().strip())
+
+    def test_downloa_bzip2_file(self):
+        fpath = cache(url='https://static.preferred.ai/cornac/tests/dummy.tar.bz2',
+                      unzip=True, relative_path='dummy/bz2.txt')
+        self.assertTrue(os.path.exists(fpath))
+        with open(fpath, 'r') as f:
+            self.assertEqual('bz2', f.read().strip())
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

Support more types of archive in addition to 'zip' in download utils

### Related Issues
<!--- If it fixes an open issue, please link to the issue here. -->


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added tests.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated `cornac/models/README.md` (if you are adding a new model).
- [ ] I have updated `examples/README.md` (if you are adding a new example model).
