### PR TITLE
Add init_utils for weight initialization

### DIFF
--- a/cornac/utils/init_utils.py
+++ b/cornac/utils/init_utils.py
@@ -1,0 +1,62 @@
+# -*- coding: utf-8 -*-
+
+"""
+@author: Quoc-Tuan Truong <tuantq.vnu@gmail.com>
+"""
+
+import numpy as np
+
+
+def zeros(shape, dtype=np.float32):
+    return np.zeros(shape, dtype=dtype)
+
+
+def ones(shape, dtype=np.float32):
+    return np.ones(shape, dtype=dtype)
+
+
+def constant(shape, val, dtype=np.float32):
+    return ones(shape, dtype=dtype) * val
+
+
+def uniform(shape, low=0, high=1, seed=None, dtype=np.float32):
+    np.random.seed(seed)
+    return np.random.uniform(low, high, shape).astype(dtype)
+
+
+def normal(shape, mean=0, std=1, seed=None, dtype=np.float32):
+    np.random.seed(seed)
+    return np.random.normal(mean, std, shape).astype(dtype)
+
+
+def xavier_uniform(shape, seed=None, dtype=np.float32):
+    """Return a numpy array by performing 'Xavier' initializer
+    also known as 'Glorot' initializer on Uniform distribution.
+
+    References
+    ----------
+    ** Xavier Glorot and Yoshua Bengio (2010):
+    [Understanding the difficulty of training deep feedforward neural networks.
+    International conference on artificial intelligence and statistics.]
+    (http://www.jmlr.org/proceedings/papers/v9/glorot10a/glorot10a.pdf)
+    """
+    assert len(shape) == 2  # only support matrix
+    std = np.sqrt(2.0 / np.sum(shape))
+    limit = np.sqrt(3.0) * std
+    return uniform(shape, -limit, limit, seed, dtype)
+
+
+def xavier_normal(shape, seed=None, dtype=np.float32):
+    """Return a numpy array by performing 'Xavier' initializer
+    also known as 'Glorot' initializer on Normal distribution.
+
+    References
+    ----------
+    ** Xavier Glorot and Yoshua Bengio (2010):
+    [Understanding the difficulty of training deep feedforward neural networks.
+    International conference on artificial intelligence and statistics.]
+    (http://www.jmlr.org/proceedings/papers/v9/glorot10a/glorot10a.pdf)
+    """
+    assert len(shape) == 2  # only support matrix
+    std = np.sqrt(2.0 / np.sum(shape))
+    return normal(shape, 0, std, seed, dtype)

--- a/tests/cornac/utils/test_init_utils.py
+++ b/tests/cornac/utils/test_init_utils.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+
+"""
+@author: Quoc-Tuan Truong <tuantq.vnu@gmail.com>
+"""
+
+import unittest
+import numpy.testing as npt
+from cornac.utils.init_utils import *
+
+
+class TestDownload(unittest.TestCase):
+
+    def setUp(self):
+        self.shape = (2, 3)
+
+    def test_zeros(self):
+        npt.assert_array_equal(zeros(self.shape ), np.zeros(self.shape, dtype=np.float32))
+
+    def test_ones(self):
+        npt.assert_array_equal(ones(self.shape ), np.ones(self.shape , dtype=np.float32))
+
+    def test_constant(self):
+        npt.assert_array_equal(constant(self.shape , val=2.5), np.ones(self.shape, dtype=np.float32) * 2.5)
+
+    def test_xavier(self):
+        std = np.sqrt(2.0 / np.sum(self.shape ))
+        limit = np.sqrt(3.0) * std
+        self.assertTrue(np.min(xavier_uniform(self.shape)) >= -limit)
+        self.assertTrue(np.max(xavier_uniform(self.shape)) <= limit)
+
+        seed = np.random.randint(123)
+        x_norm = xavier_normal(self.shape, seed=seed)
+        np.random.seed(seed)
+        npt.assert_array_equal(x_norm,
+                               np.random.normal(0, np.sqrt(2.0 / np.sum(self.shape)), self.shape).astype(np.float32))
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
Add some commonly used initializers:
- zeros, ones, constant
- uniform, normal
- xavier_uniform, xavier_normal

### Related Issues
<!--- If it fixes an open issue, please link to the issue here. -->


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added tests.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated `examples/README.md` (if you are adding a new example).
- [ ] I have updated `cornac/models/README.md` (if you are adding a new model).
