### PR TITLE
Add get_rng() function in utils

### DIFF
--- a/cornac/eval_methods/ratio_split.py
+++ b/cornac/eval_methods/ratio_split.py
@@ -4,11 +4,13 @@
 @author: Quoc-Tuan Truong <tuantq.vnu@gmail.com>
 """
 
-from ..utils.common import safe_indexing
 from math import ceil
-from .base_method import BaseMethod
-from ..experiment.result import Result
+
 import numpy as np
+
+from ..utils import get_rng
+from ..utils.common import safe_indexing
+from .base_method import BaseMethod
 
 
 class RatioSplit(BaseMethod):
@@ -40,8 +42,8 @@ class RatioSplit(BaseMethod):
     shuffle: bool, optional, default: True
         Shuffle the data before splitting.
 
-    seed: bool, optional, default: None
-        Random seed.
+    seed: int, optional, default: None
+        Random seed for reproduce the splitting.
 
     exclude_unknowns: bool, optional, default: False
         Ignore unknown users and items (cold-start) during evaluation and testing
@@ -99,11 +101,8 @@ class RatioSplit(BaseMethod):
             print("Splitting the data")
 
         data_idx = np.arange(len(self._data))
-
         if self._shuffle:
-            if self._seed is not None:
-                np.random.seed(self._seed)
-            data_idx = np.random.permutation(data_idx)
+            data_idx = get_rng(self._seed).permutation(data_idx)
 
         train_idx = data_idx[:self._train_size]
         test_idx = data_idx[-self._test_size:]

--- a/cornac/utils/__init__.py
+++ b/cornac/utils/__init__.py
@@ -1,9 +1,11 @@
 from .common import validate_format
 from .common import estimate_batches
+from .common import get_rng
 from .download import cache
-from cornac.utils.fast_dot import fast_dot
+from .fast_dot import fast_dot
 
 __all__ = ['validate_format',
            'estimate_batches',
+           'get_rng',
            'cache',
            'fast_dot']

--- a/cornac/utils/common.py
+++ b/cornac/utils/common.py
@@ -5,6 +5,8 @@
          Quoc-Tuan Truong <tuantq.vnu@gmail.com>
 """
 
+import numbers
+
 import numpy as np
 
 
@@ -43,7 +45,7 @@ def scale(values, target_min, target_max, source_min=None, source_max=None):
         source_min = np.min(values)
     if source_max is None:
         source_max = np.max(values)
-    if source_min == source_max:  #improve this scenario 
+    if source_min == source_max:  # improve this scenario
         source_min = 0.0
 
     values = (values - source_min) / (source_max - source_min)
@@ -138,3 +140,16 @@ def estimate_batches(input_size, batch_size):
     Estimate number of batches give `input_size` and `batch_size`
     """
     return int(np.ceil(input_size / batch_size))
+
+
+def get_rng(seed):
+    '''Return a RandomState of numpy.
+    If seed is None, use RandomState singleton from numpy.
+    Else if seed is an integer, create a RandomState from that seed.
+    '''
+    if seed is None:
+        return np.random.mtrand._rand
+    elif isinstance(seed, (numbers.Integral, np.integer)):
+        return np.random.RandomState(seed)
+    raise ValueError('Wrong random state. Expecting None or an int, got a '
+                     '{}'.format(type(seed)))

--- a/cornac/utils/init_utils.py
+++ b/cornac/utils/init_utils.py
@@ -6,6 +6,8 @@
 
 import numpy as np
 
+from .common import get_rng
+
 
 def zeros(shape, dtype=np.float32):
     return np.zeros(shape, dtype=dtype)
@@ -19,14 +21,12 @@ def constant(shape, val, dtype=np.float32):
     return ones(shape, dtype=dtype) * val
 
 
-def uniform(shape, low=0, high=1, seed=None, dtype=np.float32):
-    np.random.seed(seed)
-    return np.random.uniform(low, high, shape).astype(dtype)
+def uniform(shape, low=0.0, high=1.0, seed=None, dtype=np.float32):
+    return get_rng(seed).uniform(low, high, shape).astype(dtype)
 
 
-def normal(shape, mean=0, std=1, seed=None, dtype=np.float32):
-    np.random.seed(seed)
-    return np.random.normal(mean, std, shape).astype(dtype)
+def normal(shape, mean=0.0, std=1.0, seed=None, dtype=np.float32):
+    return get_rng(seed).normal(mean, std, shape).astype(dtype)
 
 
 def xavier_uniform(shape, seed=None, dtype=np.float32):


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
- The function get_rng() returns a Numpy RandomState. It should be used whenever we want to provide a seed value.
- Update init_utils and RatioSplit to use get_rng() function.

### Related Issues
<!--- If it fixes an open issue, please link to the issue here. -->


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have added tests.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated `examples/README.md` (if you are adding a new example).
- [ ] I have updated `cornac/models/README.md` (if you are adding a new model).
