### PR TITLE
Add bin_threshold option in Reader

### DIFF
--- a/cornac/data/reader.py
+++ b/cornac/data/reader.py
@@ -81,6 +81,11 @@ class Reader():
         The minimum frequency of an item to be selected.
         If `min_item_freq=1`, all items that appear in the data will be included.
 
+    bin_threshold: float, default = None
+        The rating threshold to binarize rating values (turn explicit feedback to implicit feedback).
+        For example, if `bin_threshold = 3.0`, all rating values >= 3.0 will be set to 1.0,
+        and the rest (< 3.0) will be discarded.
+
     encoding: str, default = `utf-8`
         Encoding used to decode the file.
 
@@ -91,15 +96,19 @@ class Reader():
     """
 
     def __init__(self, user_set=None, item_set=None, min_user_freq=1, min_item_freq=1,
-                 encoding='utf-8', errors=None):
+                 bin_threshold=None, encoding='utf-8', errors=None):
         self.users = user_set
         self.items = item_set
         self.min_uf = min_user_freq
         self.min_if = min_item_freq
+        self.bin_threshold = bin_threshold
         self.encoding = encoding
         self.errors = errors
 
     def filter(self, tuples):
+        if self.bin_threshold is not None:
+            tuples = [tup for tup in tuples if tup[2] >= self.bin_threshold]
+
         if self.users is not None:
             if isinstance(self.users, list):
                 self.users = set(self.users)

--- a/examples/bpr_netflix.py
+++ b/examples/bpr_netflix.py
@@ -7,23 +7,20 @@ Example for Bayesian Personalized Ranking with Netflix dataset (subset)
 """
 
 import cornac
+from cornac.data import Reader
 from cornac.datasets import netflix
 from cornac.eval_methods import RatioSplit
 
+ratio_split = RatioSplit(data=netflix.load_data_small(reader=Reader(bin_threshold=1.0)),
+                         test_size=0.1, rating_threshold=1.0,
+                         exclude_unknowns=True, verbose=True)
 
-ratio_split = RatioSplit(data=netflix.load_data_small(),
-                         test_size=0.1,
-                         rating_threshold=1.0,
-                         exclude_unknowns=True,
-                         verbose=True)
-
-bpr = cornac.models.BPR(k=10, max_iter=100, learning_rate=0.01, lambda_reg=0.01)
+bpr = cornac.models.BPR(k=10, max_iter=100, learning_rate=0.01, lambda_reg=0.01, verbose=True)
 
 auc = cornac.metrics.AUC()
 rec_20 = cornac.metrics.Recall(k=20)
 
-exp = cornac.Experiment(eval_method=ratio_split,
-                        models=[bpr],
-                        metrics=[auc, rec_20],
-                        user_based=True)
-exp.run()
+cornac.Experiment(eval_method=ratio_split,
+                  models=[bpr],
+                  metrics=[auc, rec_20],
+                  user_based=True).run()

--- a/tests/cornac/data/test_reader.py
+++ b/tests/cornac/data/test_reader.py
@@ -39,6 +39,9 @@ class TestReader(unittest.TestCase):
         self.assertEqual(triplet_data[8][0], '543')
 
     def test_filter(self):
+        reader = Reader(bin_threshold=4.0)
+        self.assertEqual(len(reader.read(self.data_file)), 8)
+
         reader = Reader(min_user_freq=2)
         self.assertEqual(len(reader.read(self.data_file)), 0)
 


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
- Add `bin_threshold` option in Reader for binarizing rating values
- Update tests for Reader
- Update `bpr_netflix` example with `bin_threshold` option in Reader

### Related Issues
<!--- If it fixes an open issue, please link to the issue here. -->


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added tests.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated `examples/README.md` (if you are adding a new example).
- [ ] I have updated `cornac/models/README.md` (if you are adding a new model).
