### PR TITLE
Adjacency matrix of Graph module has to be square

### DIFF
--- a/cornac/data/graph.py
+++ b/cornac/data/graph.py
@@ -46,11 +46,11 @@ class GraphModule(FeatureModule):
         self.val = np.asarray(self.val, dtype=np.float)
 
     def build(self, id_map=None):
-        if id_map is None:
-            raise ValueError('id_map is required but None!')
-
-        self.__matrix_size = int(max(id_map.values()) + 1)
-        self._build_triplet(id_map)
+        super().build(id_map)
+        
+        if id_map is not None:
+            self.__matrix_size = int(max(id_map.values()) + 1)
+            self._build_triplet(id_map)
         return self
 
     def get_train_triplet(self, train_row_ids, train_col_ids):

--- a/tests/cornac/data/test_graph.py
+++ b/tests/cornac/data/test_graph.py
@@ -31,7 +31,7 @@ class TestGraphModule(unittest.TestCase):
         self.assertEqual(len(gmd.map_rid), 7)
         self.assertEqual(len(gmd.map_cid), 7)
         self.assertEqual(len(gmd.val), 7)
-        self.assertEqual(gmd.matrix.shape, (7, 3))
+        self.assertEqual(gmd.matrix.shape, (7, 7))
 
         try:
             GraphModule().build()


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
- Make sure the adjacency matrix of the Graph module is a square matrix
- Only build triplets when `id_map` is provided
- Call `super()` to `FeatureModule.build()`

### Related Issues
<!--- If it fixes an open issue, please link to the issue here. -->


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added tests.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated `examples/README.md` (if you are adding a new example).
- [ ] I have updated `cornac/models/README.md` (if you are adding a new model).
