### PR TITLE
Only input stop words into BaseTokenizer

### DIFF
--- a/cornac/data/text.py
+++ b/cornac/data/text.py
@@ -266,11 +266,6 @@ class CountVectorizer():
         `max_features` ordered by term frequency across the corpus.
         If `vocab` is not None, this will be ignored.
 
-    stop_words : Collection, str, default: None
-        Collection of stop words which will be ignored when building `Vocabulary`.
-        If str, it indicates a built-in stop words list. Currently, only
-        `english` is supported.
-
     binary : boolean, default=False
         If True, all non zero counts are set to 1.
     """
@@ -281,11 +276,8 @@ class CountVectorizer():
                  max_doc_freq: Union[float, int] = 1.0,
                  min_freq: int = 1,
                  max_features: int = None,
-                 stop_words: Union[List, str] = None,
                  binary: bool = False):
-        self.tokenizer = tokenizer
-        if tokenizer is None:
-            self.tokenizer = BaseTokenizer(stop_words=stop_words)
+        self.tokenizer = BaseTokenizer() if tokenizer is None else tokenizer
         self.vocab = vocab
         self.max_doc_freq = max_doc_freq
         self.min_freq = min_freq
@@ -296,7 +288,6 @@ class CountVectorizer():
             if max_features <= 0:
                 raise ValueError('max_features=%r, '
                                  'neither a positive integer nor None' % max_features)
-        self.stop_words = stop_words
         self.binary = binary
 
     def _limit_features(self, X: sp.csr_matrix, max_doc_count: int):
@@ -467,11 +458,6 @@ class TextModule(FeatureModule):
         The minimum frequency of tokens to be included into vocabulary.
         If `vocab` is not None, this will be ignored.
 
-    stop_words : Collection, str, default: None
-        Collection of stop words which will be ignored when building `Vocabulary`.
-        If str, it indicates a built-in stop words list. Currently, only
-        `english` is supported.
-
     """
 
     def __init__(self,
@@ -482,16 +468,14 @@ class TextModule(FeatureModule):
                  max_vocab: int = None,
                  max_doc_freq: Union[float, int] = 1.0,
                  min_freq: int = 1,
-                 stop_words: Union[List, str] = None,
                  **kwargs):
         super().__init__(ids=ids, **kwargs)
         self.corpus = corpus
-        self.tokenizer = tokenizer
+        self.tokenizer = BaseTokenizer() if tokenizer is None else tokenizer
         self.vocab = vocab
         self.max_vocab = max_vocab
         self.max_doc_freq = max_doc_freq
         self.min_freq = min_freq
-        self.stop_words = stop_words
         self.sequences = None
         self.count_matrix = None
 
@@ -514,8 +498,7 @@ class TextModule(FeatureModule):
 
         vectorizer = CountVectorizer(tokenizer=self.tokenizer, vocab=self.vocab,
                                      max_doc_freq=self.max_doc_freq, min_freq=self.min_freq,
-                                     stop_words=self.stop_words, max_features=self.max_vocab,
-                                     binary=False)
+                                     max_features=self.max_vocab, binary=False)
         self.sequences, self.count_matrix = vectorizer.fit_transform(self.corpus)
         self.vocab = Vocabulary(vectorizer.vocab.idx2tok, use_special_tokens=True)
         # Map tokens into integer ids

--- a/examples/cdl_example.py
+++ b/examples/cdl_example.py
@@ -19,9 +19,8 @@ data = citeulike.load_data(reader=Reader(item_set=item_ids))
 
 # build text module
 item_text_module = TextModule(corpus=docs, ids=item_ids,
-                              tokenizer=BaseTokenizer(sep=' '),
-                              max_vocab=8000, max_doc_freq=0.5,
-                              stop_words='english')
+                              tokenizer=BaseTokenizer(stop_words='english'),
+                              max_vocab=8000, max_doc_freq=0.5)
 
 ratio_split = RatioSplit(data=data, test_size=0.2, exclude_unknowns=True,
                          item_text=item_text_module, verbose=True, seed=123, rating_threshold=0.5)

--- a/examples/cdr_example.py
+++ b/examples/cdr_example.py
@@ -18,9 +18,8 @@ data = citeulike.load_data(reader=Reader(item_set=item_ids))
 
 # build text module
 item_text_module = TextModule(corpus=docs, ids=item_ids,
-                              tokenizer=BaseTokenizer('\t'),
-                              max_vocab=8000, max_doc_freq=0.5,
-                              stop_words='english')
+                              tokenizer=BaseTokenizer(stop_words='english'),
+                              max_vocab=8000, max_doc_freq=0.5)
 
 ratio_split = RatioSplit(data=data, test_size=0.2, exclude_unknowns=True,
                          item_text=item_text_module, verbose=True, seed=123, rating_threshold=0.5)

--- a/examples/conv_mf_example.py
+++ b/examples/conv_mf_example.py
@@ -18,8 +18,8 @@ ml_1m = movielens.load_1m(reader=Reader(item_set=movie_ids))
 
 # build text module
 item_text_module = TextModule(corpus=plots, ids=movie_ids,
-                              tokenizer=BaseTokenizer('\t'),
-                              max_vocab=8000, max_doc_freq=0.5, stop_words='english')
+                              tokenizer=BaseTokenizer(sep='\t', stop_words='english'),
+                              max_vocab=8000, max_doc_freq=0.5)
 
 ratio_split = RatioSplit(data=ml_1m, test_size=0.2, exclude_unknowns=True,
                          item_text=item_text_module, verbose=True, seed=123)

--- a/examples/cvae_example.py
+++ b/examples/cvae_example.py
@@ -11,14 +11,15 @@ from cornac.data import Reader
 from cornac.datasets import citeulike
 from cornac.eval_methods import RatioSplit
 from cornac.data import TextModule
+from cornac.data.text import BaseTokenizer
 
 docs, item_ids = citeulike.load_text()
 data = citeulike.load_data(reader=Reader(item_set=item_ids))
 
 # build text module
 item_text_module = TextModule(corpus=docs, ids=item_ids,
-                              max_vocab=8000, max_doc_freq=0.5,
-                              stop_words='english')
+                              tokenizer=BaseTokenizer(stop_words='english'),
+                              max_vocab=8000, max_doc_freq=0.5)
 
 ratio_split = RatioSplit(data=data, test_size=0.2, exclude_unknowns=True,
                          rating_threshold=0.5, verbose=True, seed=123,

--- a/tests/cornac/utils/test_download.py
+++ b/tests/cornac/utils/test_download.py
@@ -33,7 +33,7 @@ class TestDownload(unittest.TestCase):
         with open(fpath, 'r') as f:
             self.assertEqual('gz', f.read().strip())
 
-    def test_downloa_bzip2_file(self):
+    def test_download_bzip2_file(self):
         fpath = cache(url='https://static.preferred.ai/cornac/tests/dummy.tar.bz2',
                       unzip=True, relative_path='dummy/bz2.txt')
         self.assertTrue(os.path.exists(fpath))


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
- Remove `stopwords` from `TextModule` and `CountVectorizer`
- Only input stop words into BaseTokenizer.

### Related Issues
<!--- If it fixes an open issue, please link to the issue here. -->


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have added tests.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated `examples/README.md` (if you are adding a new example).
- [ ] I have updated `cornac/models/README.md` (if you are adding a new model).
