### PR TITLE
Add Amazon Toys and Games datasets with extracted sentiment data

### DIFF
--- a/cornac/datasets/amazon_toy.py
+++ b/cornac/datasets/amazon_toy.py
@@ -1,0 +1,64 @@
+# Copyright 2018 The Cornac Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ============================================================================
+"""
+This data is built based on the Amazon datasets
+provided by Julian McAuley at: http://jmcauley.ucsd.edu/data/amazon/
+"""
+
+from ..utils import cache
+from ..data import Reader
+from typing import List
+
+
+def load_rating(reader: Reader = None) -> List:
+    """Load the user-item ratings
+
+    Parameters
+    ----------
+    reader: `obj:cornac.data.Reader`, default: None
+        Reader object used to read the data.
+
+    Returns
+    -------
+    data: array-like
+        Data in the form of a list of tuples (user, item, rating).
+    """
+    fpath = cache(url='https://static.preferred.ai/cornac/datasets/amazon_toy/rating.zip',
+                  unzip=True, relative_path='amazon_toy/rating.txt')
+    reader = Reader() if reader is None else reader
+    return reader.read(fpath, fmt='UIR', sep=',')
+
+def load_sentiment(reader: Reader = None) -> List:
+    """Load the user-item-sentiments
+    The dataset was constructed by the method described in the reference paper.
+
+    Parameters
+    ----------
+    reader: `obj:cornac.data.Reader`, default: None
+        Reader object used to read the data.
+
+    Returns
+    -------
+    data: array-like
+        Data in the form of a list of tuples (user, item, [(aspect, opinion, sentiment), (aspect, opinion, sentiment), ...]).
+
+    References
+    ----------
+    Gao, J., Wang, X., Wang, Y., & Xie, X. (2019). Explainable Recommendation Through Attentive Multi-View Learning. AAAI.
+    """
+    fpath = cache(url='https://static.preferred.ai/cornac/datasets/amazon_toy/sentiment.zip',
+                  unzip=True, relative_path='amazon_toy/sentiment.txt')
+    reader = Reader() if reader is None else reader
+    return reader.read(fpath, fmt='UITup', sep=',', tup_sep=':')

--- a/docs/source/datasets.rst
+++ b/docs/source/datasets.rst
@@ -15,6 +15,11 @@ Amazon Office
 .. automodule:: cornac.datasets.amazon_office
    :members:
 
+Amazon Toys and Games
+---------------------------------------------
+.. automodule:: cornac.datasets.amazon_toy
+   :members:
+
 CiteULike
 -----------------------------------------
 .. automodule:: cornac.datasets.citeulike

--- a/tests/cornac/datasets/test_amazon_toy.py
+++ b/tests/cornac/datasets/test_amazon_toy.py
@@ -13,11 +13,23 @@
 # limitations under the License.
 # ============================================================================
 
-from . import amazon_clothing
-from . import amazon_office
-from . import amazon_toy
-from . import citeulike
-from . import epinions
-from . import movielens
-from . import netflix
-from . import tradesy
+import unittest
+import random
+import time
+
+from cornac.datasets import amazon_toy as toy
+
+
+class TestAmazonToy(unittest.TestCase):
+
+    def test_amazon_toy(self):
+        random.seed(time.time())
+        if random.random() > 0.8:
+            ratings = toy.load_rating()
+            sentiments = toy.load_sentiment()
+            self.assertEqual(len(ratings), 167597)
+            self.assertEqual(len(sentiments), 149877)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
Add Amazon Toys and Games datasets with extracted sentiment data
<!--- Why is this change required? What problem does it solve? -->
A typical data set for explainable recommendation models that use aspect sentiment information

### Related Issues
<!--- If it fixes an open issue, please link to the issue here. -->


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added tests.
- [x] I have updated the documentation accordingly.
- [ ] I have updated `README.md` (if you are adding a new model).
- [ ] I have updated `examples/README.md` (if you are adding a new example).
