### PR TITLE
Add Amazon Clothing dataset

### DIFF
--- a/cornac/datasets/__init__.py
+++ b/cornac/datasets/__init__.py
@@ -16,6 +16,7 @@
 from . import amazon_clothing
 from . import amazon_office
 from . import citeulike
+from . import epinions
 from . import movielens
 from . import netflix
 from . import tradesy

--- a/cornac/datasets/__init__.py
+++ b/cornac/datasets/__init__.py
@@ -13,8 +13,9 @@
 # limitations under the License.
 # ============================================================================
 
-from . import movielens
-from . import tradesy
-from . import netflix
+from . import amazon_clothing
 from . import amazon_office
 from . import citeulike
+from . import movielens
+from . import netflix
+from . import tradesy

--- a/cornac/datasets/amazon_clothing.py
+++ b/cornac/datasets/amazon_clothing.py
@@ -1,0 +1,99 @@
+# Copyright 2018 The Cornac Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ============================================================================
+"""
+This data is built based on the Amazon datasets provided by Julian McAuley @ http://jmcauley.ucsd.edu/data/amazon/.
+We make sure all items having three types of auxiliary data: text, image, and context (items appearing together).
+"""
+
+from typing import List
+
+import numpy as np
+
+from ..utils import cache
+from ..data import Reader
+from ..data.reader import read_text
+
+
+def load_rating(reader: Reader = None) -> List:
+    """Load the user-item ratings
+
+    Parameters
+    ----------
+    reader: `obj:cornac.data.Reader`, default: None
+        Reader object used to read the data.
+
+    Returns
+    -------
+    data: array-like
+        Data in the form of a list of tuples (user, item, rating).
+    """
+    fpath = cache(url='https://static.preferred.ai/cornac/datasets/amazon_clothing/rating.zip',
+                  unzip=True, relative_path='amazon_clothing/rating.txt')
+    reader = Reader() if reader is None else reader
+    return reader.read(fpath, sep='\t')
+
+
+def load_text():
+    """Load the item text descriptions
+
+    Returns
+    -------
+    texts: List
+        List of text documents, one per item.
+
+    ids: List
+        List of item ids aligned with indices in `texts`.
+    """
+    fpath = cache(url='https://static.preferred.ai/cornac/datasets/amazon_clothing/text.zip',
+                  unzip=True, relative_path='amazon_clothing/text.txt')
+    texts, ids = read_text(fpath, sep='::')
+    return texts, ids
+
+
+def load_image():
+    """Load the item image in the form of visual features (extracted from pre-trained CNN)
+
+    Returns
+    -------
+    features: numpy.ndarray
+        Feature matrix with shape (n, 4096) with n is the number of items.
+
+    item_ids: List
+        List of item ids aligned with indices in `features`.
+    """
+    features = np.load(cache(url='https://static.preferred.ai/cornac/datasets/amazon_clothing/image.zip',
+                             unzip=True, relative_path='amazon_clothing/image_features.npy'))
+    item_ids = read_text(cache(url='https://static.preferred.ai/cornac/datasets/amazon_clothing/item_ids.zip',
+                               unzip=True, relative_path='amazon_clothing/item_ids.txt'))
+    return features, item_ids
+
+
+def load_context(reader: Reader = None) -> List:
+    """Load the item-item interactions
+
+    Parameters
+    ----------
+    reader: `obj:cornac.data.Reader`, default: None
+        Reader object used to read the data.
+
+    Returns
+    -------
+    data: array-like
+        Data in the form of a list of tuples (item, item, 1).
+    """
+    fpath = cache(url='https://static.preferred.ai/cornac/datasets/amazon_clothing/context.zip',
+                  unzip=True, relative_path='amazon_clothing/context.txt')
+    reader = Reader() if reader is None else reader
+    return reader.read(fpath, fmt='UI', sep='\t')

--- a/docs/source/datasets.rst
+++ b/docs/source/datasets.rst
@@ -4,20 +4,10 @@ Built-in datasets
 
 .. automodule:: cornac.datasets
     :members:
-	
-MovieLens
------------------------------------------
-.. automodule:: cornac.datasets.movielens
-   :members:
 
-Netflix
----------------------------------------
-.. automodule:: cornac.datasets.netflix
-   :members:
-
-Tradesy
----------------------------------------
-.. automodule:: cornac.datasets.tradesy
+Amazon Clothing
+-----------------------------------------------
+.. automodule:: cornac.datasets.amazon_clothing
    :members:
 
 Amazon Office
@@ -34,3 +24,19 @@ Epinions
 -----------------------------------------
 .. automodule:: cornac.datasets.epinions
    :members:
+
+MovieLens
+-----------------------------------------
+.. automodule:: cornac.datasets.movielens
+   :members:
+
+Netflix
+---------------------------------------
+.. automodule:: cornac.datasets.netflix
+   :members:
+
+Tradesy
+---------------------------------------
+.. automodule:: cornac.datasets.tradesy
+   :members:
+

--- a/tests/cornac/datasets/test_amazon_clothing.py
+++ b/tests/cornac/datasets/test_amazon_clothing.py
@@ -27,7 +27,7 @@ class TestAmazonClothing(unittest.TestCase):
         if random.random() > 0.8:
             # ignore image because of big size
             ratings = amazon_clothing.load_rating()
-            texts = amazon_clothing.load_text()
+            texts, item_ids = amazon_clothing.load_text()
             contexts = amazon_clothing.load_context()
             self.assertEqual(len(ratings), 13689)
             self.assertEqual(len(texts), 3393)

--- a/tests/cornac/datasets/test_amazon_clothing.py
+++ b/tests/cornac/datasets/test_amazon_clothing.py
@@ -1,0 +1,38 @@
+# Copyright 2018 The Cornac Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ============================================================================
+
+import unittest
+import random
+import time
+
+from cornac.datasets import amazon_clothing
+
+
+class TestAmazonClothing(unittest.TestCase):
+
+    def test_amazon_clothing(self):
+        random.seed(time.time())
+        if random.random() > 0.8:
+            # ignore image because of big size
+            ratings = amazon_clothing.load_rating()
+            texts = amazon_clothing.load_text()
+            contexts = amazon_clothing.load_context()
+            self.assertEqual(len(ratings), 13689)
+            self.assertEqual(len(texts), 3393)
+            self.assertEqual(len(contexts), 9198)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
Add Amazon Clothing dataset including:
 - rating data
 - item text descriptions
 - item images
 - item context (items appearing together)

### Related Issues
<!--- If it fixes an open issue, please link to the issue here. -->


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have added tests.
- [x] I have updated the documentation accordingly.
- [ ] I have updated `README.md` (if you are adding a new model).
- [ ] I have updated `examples/README.md` (if you are adding a new example).
