### PR TITLE
Remove shuffle option in RatioSplit

### DIFF
--- a/examples/c2pf_example.py
+++ b/examples/c2pf_example.py
@@ -29,8 +29,8 @@ item_graph_modality = GraphModality(data=contexts)
 
 ratio_split = RatioSplit(data=ratings,
                          test_size=0.2, rating_threshold=3.5,
-                         shuffle=True, exclude_unknowns=True,
-                         verbose=True, item_graph=item_graph_modality)
+                         exclude_unknowns=True, verbose=True,
+                         item_graph=item_graph_modality)
 
 c2pf = C2PF(k=100, max_iter=80, variant='c2pf')
 

--- a/examples/mcf_office.py
+++ b/examples/mcf_office.py
@@ -29,8 +29,8 @@ item_graph_modality = GraphModality(data=contexts)
 
 ratio_split = RatioSplit(data=ratings,
                          test_size=0.2, rating_threshold=3.5,
-                         shuffle=True, exclude_unknowns=True,
-                         verbose=True, item_graph=item_graph_modality)
+                         exclude_unknowns=True, verbose=True,
+                         item_graph=item_graph_modality)
 
 mcf = MCF(k=10, max_iter=40, learning_rate=0.001, verbose=True)
 

--- a/examples/pcrl_example.py
+++ b/examples/pcrl_example.py
@@ -32,8 +32,8 @@ item_graph_modality = GraphModality(data=contexts)
 
 ratio_split = RatioSplit(data=ratings,
                          test_size=0.2, rating_threshold=3.5,
-                         shuffle=True, exclude_unknowns=True,
-                         verbose=True, item_graph=item_graph_modality)
+                         exclude_unknowns=True, verbose=True,
+                         item_graph=item_graph_modality)
 
 pcrl = PCRL(k=100, z_dims=[300],
             max_iter=300, 

--- a/tests/cornac/eval_methods/test_ratio_split.py
+++ b/tests/cornac/eval_methods/test_ratio_split.py
@@ -74,9 +74,9 @@ class TestRatioSplit(unittest.TestCase):
 
     def test_splits(self):
         ratio_split = RatioSplit(self.data, test_size=0.1, val_size=0.1, seed=123, verbose=True)
-        ratio_split._split()
-        self.assertTrue(ratio_split._split_ran)
-        ratio_split._split()
+        self.assertTrue(ratio_split.train_size == 8)
+        self.assertTrue(ratio_split.val_size == 1)
+        self.assertTrue(ratio_split.test_size == 1)
 
     def test_evaluate(self):
         ratio_split = RatioSplit(self.data, exclude_unknowns=True, verbose=True)


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
Remove `shuffle` option in `RatioSplit` evaluation method.
Data is always shuffled before split into training, validation, and test sets.

### Related Issues
<!--- If it fixes an open issue, please link to the issue here. -->


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have added tests.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated `README.md` (if you are adding a new model).
- [ ] I have updated `examples/README.md` (if you are adding a new example).
