### PR TITLE
Add num_zeros argument into uir_iter to support negative sampling

### DIFF
--- a/tests/cornac/data/test_trainset.py
+++ b/tests/cornac/data/test_trainset.py
@@ -122,6 +122,10 @@ class TestMatrixTrainSet(unittest.TestCase):
         ratings = [batch_ratings for _, _, batch_ratings in train_set.uir_iter()]
         self.assertListEqual(ratings, [4, 4, 4, 4, 3, 4, 4, 5, 3, 4])
 
+        ratings = [batch_ratings for _, _, batch_ratings in train_set.uir_iter(batch_size=5, num_zeros=1)]
+        self.assertListEqual(ratings[0].tolist(), [4, 4, 4, 4, 3, 0, 0, 0, 0, 0])
+        self.assertListEqual(ratings[1].tolist(), [4, 4, 5, 3, 4, 0, 0, 0, 0, 0])
+
     def test_uij_iter(self):
         train_set = MatrixTrainSet.from_uir(self.triplet_data, global_uid_map={}, global_iid_map={},
                                             global_ui_set=set(), verbose=True)


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
Add `num_zeros` argument into `TrainSet.uir_iter` to support negative sampling

### Related Issues
<!--- If it fixes an open issue, please link to the issue here. -->


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added tests.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated `README.md` (if you are adding a new model).
- [ ] I have updated `examples/README.md` (if you are adding a new example).
