### PR TITLE
Support early stopping in Recommender

### DIFF
--- a/cornac/models/recommender.py
+++ b/cornac/models/recommender.py
@@ -191,7 +191,7 @@ class Recommender:
             Loss value on validation set.
             Return `None` if `val_set` is `None`.
         """
-        raise NotImplementedError('Overwrite me!')
+        raise NotImplementedError('Overwritten me!')
 
     def early_stop(self, min_delta=0., patience=0):
         """Check if training should be stopped when validation loss has stopped improving.

--- a/cornac/models/recommender.py
+++ b/cornac/models/recommender.py
@@ -37,6 +37,13 @@ class Recommender:
         self.trainable = trainable
         self.verbose = verbose
         self.train_set = None
+        self.val_set = None
+
+        self.best_loss = np.Inf
+        self.best_epoch = 0
+        self.current_epoch = 0
+        self.stopped_epoch = 0
+        self.wait = 0
 
     def fit(self, train_set, val_set=None):
         """Fit the model to observations. Need to
@@ -173,3 +180,53 @@ class Recommender:
             item_rank = intersects(item_rank, item_ids, assume_unique=True)
             item_scores = item_scores[item_ids]
         return item_rank, item_scores
+
+    def val_loss(self):
+        """Calculating loss on validation set (`val_set`). This function will be called by `early_stop()`.
+        Note: `val_set` could be `None` thus it needs to be checked before usage.
+
+        Returns
+        -------
+        res : float
+            Loss value on validation set.
+            Return `None` if `val_set` is `None`.
+        """
+        raise NotImplementedError('Overwrite me!')
+
+    def early_stop(self, min_delta=0., patience=0):
+        """Check if training should be stopped when validation loss has stopped improving.
+
+        Parameters
+        ----------
+        min_delta: float, optional, default: 0.
+            The minimum reduction on validation loss to be considered as improvement,
+            i.e. a reduction of less than min_delta will count as no improvement.
+
+        patience: int, optional, default: 0
+            Number of epochs with no improvement after which training should be stopped.
+
+        Returns
+        -------
+        res : bool
+            Return `True` if model training should be stopped (no improvement on validation set),
+            otherwise return `False`.
+        """
+        self.current_epoch += 1
+        current_loss = self.val_loss()
+        if current_loss is None:
+            return False
+
+        if np.less_equal(current_loss, self.best_loss - min_delta):
+            self.best_loss = current_loss
+            self.best_epoch = self.current_epoch
+            self.wait = 0
+        else:
+            self.wait += 1
+            if self.wait >= patience:
+                self.stopped_epoch = self.current_epoch
+
+        if self.stopped_epoch > 0:
+            print('Early stopping: best epoch = %d, '
+                  'stopped epoch = %d' % (self.best_epoch, self.stopped_epoch))
+            return True
+        return False


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
- Call `early_stop()` to check if training should be stopped
- `val_loss()` function needs to be overwritten in order to use `early_stop()`

### Related Issues
<!--- If it fixes an open issue, please link to the issue here. -->


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have added tests.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated `README.md` (if you are adding a new model).
- [ ] I have updated `examples/README.md` (if you are adding a new example).
