### PR TITLE
Fix bug in read_text() function of reader

### DIFF
--- a/cornac/data/reader.py
+++ b/cornac/data/reader.py
@@ -42,7 +42,7 @@ def read_text(fpath, sep=None, encoding='utf-8', errors=None):
     """
     with open(fpath, encoding=encoding, errors=errors) as f:
         if sep is None:
-            return f.read().splitlines()
+            return [line.strip() for line in f]
         else:
             texts, ids = [], []
             for line in f:


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
- Replace `splitlines()` function by list comprehension to avoid special endline characters

### Related Issues
<!--- If it fixes an open issue, please link to the issue here. -->


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have added tests.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated `README.md` (if you are adding a new model).
- [ ] I have updated `examples/README.md` (if you are adding a new example).
