### PR TITLE
Update naming convention for users and items

### DIFF
--- a/cornac/models/baseline_only/recom_bo.cpp
+++ b/cornac/models/baseline_only/recom_bo.cpp
@@ -2490,18 +2490,17 @@ static const char __pyx_k_disable[] = "disable";
 static const char __pyx_k_fit_sgd[] = "_fit_sgd";
 static const char __pyx_k_float32[] = "float32";
 static const char __pyx_k_fortran[] = "fortran";
-static const char __pyx_k_item_id[] = "item_id";
 static const char __pyx_k_memview[] = "memview";
 static const char __pyx_k_n_items[] = "n_items";
 static const char __pyx_k_n_users[] = "n_users";
 static const char __pyx_k_prepare[] = "__prepare__";
-static const char __pyx_k_user_id[] = "user_id";
 static const char __pyx_k_val_set[] = "val_set";
 static const char __pyx_k_verbose[] = "verbose";
 static const char __pyx_k_Ellipsis[] = "Ellipsis";
 static const char __pyx_k_defaults[] = "defaults";
 static const char __pyx_k_getstate[] = "__getstate__";
 static const char __pyx_k_i_biases[] = "i_biases";
+static const char __pyx_k_item_idx[] = "item_idx";
 static const char __pyx_k_itemsize[] = "itemsize";
 static const char __pyx_k_max_iter[] = "max_iter";
 static const char __pyx_k_progress[] = "progress";
@@ -2511,6 +2510,7 @@ static const char __pyx_k_setstate[] = "__setstate__";
 static const char __pyx_k_u_biases[] = "u_biases";
 static const char __pyx_k_unk_item[] = "unk_item";
 static const char __pyx_k_unk_user[] = "unk_user";
+static const char __pyx_k_user_idx[] = "user_idx";
 static const char __pyx_k_TypeError[] = "TypeError";
 static const char __pyx_k_cpu_count[] = "cpu_count";
 static const char __pyx_k_enumerate[] = "enumerate";
@@ -2711,7 +2711,7 @@ static PyObject *__pyx_kp_s_int_double;
 static PyObject *__pyx_kp_s_int_float;
 static PyObject *__pyx_n_s_is_unk_item;
 static PyObject *__pyx_n_s_is_unk_user;
-static PyObject *__pyx_n_s_item_id;
+static PyObject *__pyx_n_s_item_idx;
 static PyObject *__pyx_n_s_item_score;
 static PyObject *__pyx_n_s_itemsize;
 static PyObject *__pyx_kp_s_itemsize_0_for_cython_array;
@@ -2816,7 +2816,7 @@ static PyObject *__pyx_n_s_unk_user;
 static PyObject *__pyx_kp_u_unknown_dtype_code_in_numpy_pxd;
 static PyObject *__pyx_n_s_unpack;
 static PyObject *__pyx_n_s_update;
-static PyObject *__pyx_n_s_user_id;
+static PyObject *__pyx_n_s_user_idx;
 static PyObject *__pyx_n_s_utils_init_utils;
 static PyObject *__pyx_n_s_val;
 static PyObject *__pyx_n_s_val_set;
@@ -2831,7 +2831,7 @@ static PyObject *__pyx_pf_6cornac_6models_13baseline_only_8recom_bo_12BaselineOn
 static PyObject *__pyx_pf_6cornac_6models_13baseline_only_8recom_bo_12BaselineOnly_14_fit_sgd(CYTHON_UNUSED PyObject *__pyx_self, PyObject *__pyx_v_self, __Pyx_memviewslice __pyx_v_rid, __Pyx_memviewslice __pyx_v_cid, __Pyx_memviewslice __pyx_v_val, __Pyx_memviewslice __pyx_v_Bu, __Pyx_memviewslice __pyx_v_Bi); /* proto */
 static PyObject *__pyx_pf_6cornac_6models_13baseline_only_8recom_bo_12BaselineOnly_16_fit_sgd(CYTHON_UNUSED PyObject *__pyx_self, PyObject *__pyx_v_self, __Pyx_memviewslice __pyx_v_rid, __Pyx_memviewslice __pyx_v_cid, __Pyx_memviewslice __pyx_v_val, __Pyx_memviewslice __pyx_v_Bu, __Pyx_memviewslice __pyx_v_Bi); /* proto */
 static PyObject *__pyx_pf_6cornac_6models_13baseline_only_8recom_bo_12BaselineOnly_18_fit_sgd(CYTHON_UNUSED PyObject *__pyx_self, PyObject *__pyx_v_self, __Pyx_memviewslice __pyx_v_rid, __Pyx_memviewslice __pyx_v_cid, __Pyx_memviewslice __pyx_v_val, __Pyx_memviewslice __pyx_v_Bu, __Pyx_memviewslice __pyx_v_Bi); /* proto */
-static PyObject *__pyx_pf_6cornac_6models_13baseline_only_8recom_bo_12BaselineOnly_6score(CYTHON_UNUSED PyObject *__pyx_self, PyObject *__pyx_v_self, PyObject *__pyx_v_user_id, PyObject *__pyx_v_item_id); /* proto */
+static PyObject *__pyx_pf_6cornac_6models_13baseline_only_8recom_bo_12BaselineOnly_6score(CYTHON_UNUSED PyObject *__pyx_self, PyObject *__pyx_v_self, PyObject *__pyx_v_user_idx, PyObject *__pyx_v_item_idx); /* proto */
 static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, Py_buffer *__pyx_v_info, int __pyx_v_flags); /* proto */
 static void __pyx_pf_5numpy_7ndarray_2__releasebuffer__(PyArrayObject *__pyx_v_self, Py_buffer *__pyx_v_info); /* proto */
 static int __pyx_array___pyx_pf_15View_dot_MemoryView_5array___cinit__(struct __pyx_array_obj *__pyx_v_self, PyObject *__pyx_v_shape, Py_ssize_t __pyx_v_itemsize, PyObject *__pyx_v_format, PyObject *__pyx_v_mode, int __pyx_v_allocate_buffer); /* proto */
@@ -3419,7 +3419,7 @@ static PyObject *__pyx_pf_6cornac_6models_13baseline_only_8recom_bo_12BaselineOn
 
 /* Python wrapper */
 static PyObject *__pyx_pw_6cornac_6models_13baseline_only_8recom_bo_12BaselineOnly_3fit(PyObject *__pyx_self, PyObject *__pyx_args, PyObject *__pyx_kwds); /*proto*/
-static char __pyx_doc_6cornac_6models_13baseline_only_8recom_bo_12BaselineOnly_2fit[] = "Fit the model to observations.\n\n        Parameters\n        ----------\n        train_set: :obj:`cornac.data.MultimodalTrainSet`, required\n            User-Item preference data as well as additional modalities.\n\n        val_set: :obj:`cornac.data.MultimodalTestSet`, optional, default: None\n            User-Item preference data for model selection purposes (e.g., early stopping).\n\n        Returns\n        -------\n        self : object\n        ";
+static char __pyx_doc_6cornac_6models_13baseline_only_8recom_bo_12BaselineOnly_2fit[] = "Fit the model to observations.\n\n        Parameters\n        ----------\n        train_set: :obj:`cornac.data.Dataset`, required\n            User-Item preference data as well as additional modalities.\n\n        val_set: :obj:`cornac.data.Dataset`, optional, default: None\n            User-Item preference data for model selection purposes (e.g., early stopping).\n\n        Returns\n        -------\n        self : object\n        ";
 static PyMethodDef __pyx_mdef_6cornac_6models_13baseline_only_8recom_bo_12BaselineOnly_3fit = {"fit", (PyCFunction)(void*)(PyCFunctionWithKeywords)__pyx_pw_6cornac_6models_13baseline_only_8recom_bo_12BaselineOnly_3fit, METH_VARARGS|METH_KEYWORDS, __pyx_doc_6cornac_6models_13baseline_only_8recom_bo_12BaselineOnly_2fit};
 static PyObject *__pyx_pw_6cornac_6models_13baseline_only_8recom_bo_12BaselineOnly_3fit(PyObject *__pyx_self, PyObject *__pyx_args, PyObject *__pyx_kwds) {
   PyObject *__pyx_v_self = 0;
@@ -9792,24 +9792,24 @@ static PyObject *__pyx_pf_6cornac_6models_13baseline_only_8recom_bo_12BaselineOn
 /* "cornac/models/baseline_only/recom_bo.pyx":173
  * 
  * 
- *     def score(self, user_id, item_id=None):             # <<<<<<<<<<<<<<
+ *     def score(self, user_idx, item_idx=None):             # <<<<<<<<<<<<<<
  *         """Predict the scores/ratings of a user for an item.
  * 
  */
 
 /* Python wrapper */
 static PyObject *__pyx_pw_6cornac_6models_13baseline_only_8recom_bo_12BaselineOnly_7score(PyObject *__pyx_self, PyObject *__pyx_args, PyObject *__pyx_kwds); /*proto*/
-static char __pyx_doc_6cornac_6models_13baseline_only_8recom_bo_12BaselineOnly_6score[] = "Predict the scores/ratings of a user for an item.\n\n        Parameters\n        ----------\n        user_id: int, required\n            The index of the user for whom to perform score prediction.\n\n        item_id: int, optional, default: None\n            The index of the item for that to perform score prediction.\n            If None, scores for all known items will be returned.\n\n        Returns\n        -------\n        res : A scalar or a Numpy array\n            Relative scores that the user gives to the item or to all known items\n\n        ";
+static char __pyx_doc_6cornac_6models_13baseline_only_8recom_bo_12BaselineOnly_6score[] = "Predict the scores/ratings of a user for an item.\n\n        Parameters\n        ----------\n        user_idx: int, required\n            The index of the user for whom to perform score prediction.\n\n        item_idx: int, optional, default: None\n            The index of the item for that to perform score prediction.\n            If None, scores for all known items will be returned.\n\n        Returns\n        -------\n        res : A scalar or a Numpy array\n            Relative scores that the user gives to the item or to all known items\n\n        ";
 static PyMethodDef __pyx_mdef_6cornac_6models_13baseline_only_8recom_bo_12BaselineOnly_7score = {"score", (PyCFunction)(void*)(PyCFunctionWithKeywords)__pyx_pw_6cornac_6models_13baseline_only_8recom_bo_12BaselineOnly_7score, METH_VARARGS|METH_KEYWORDS, __pyx_doc_6cornac_6models_13baseline_only_8recom_bo_12BaselineOnly_6score};
 static PyObject *__pyx_pw_6cornac_6models_13baseline_only_8recom_bo_12BaselineOnly_7score(PyObject *__pyx_self, PyObject *__pyx_args, PyObject *__pyx_kwds) {
   PyObject *__pyx_v_self = 0;
-  PyObject *__pyx_v_user_id = 0;
-  PyObject *__pyx_v_item_id = 0;
+  PyObject *__pyx_v_user_idx = 0;
+  PyObject *__pyx_v_item_idx = 0;
   PyObject *__pyx_r = 0;
   __Pyx_RefNannyDeclarations
   __Pyx_RefNannySetupContext("score (wrapper)", 0);
   {
-    static PyObject **__pyx_pyargnames[] = {&__pyx_n_s_self,&__pyx_n_s_user_id,&__pyx_n_s_item_id,0};
+    static PyObject **__pyx_pyargnames[] = {&__pyx_n_s_self,&__pyx_n_s_user_idx,&__pyx_n_s_item_idx,0};
     PyObject* values[3] = {0,0,0};
     values[2] = ((PyObject *)((PyObject *)Py_None));
     if (unlikely(__pyx_kwds)) {
@@ -9832,14 +9832,14 @@ static PyObject *__pyx_pw_6cornac_6models_13baseline_only_8recom_bo_12BaselineOn
         else goto __pyx_L5_argtuple_error;
         CYTHON_FALLTHROUGH;
         case  1:
-        if (likely((values[1] = __Pyx_PyDict_GetItemStr(__pyx_kwds, __pyx_n_s_user_id)) != 0)) kw_args--;
+        if (likely((values[1] = __Pyx_PyDict_GetItemStr(__pyx_kwds, __pyx_n_s_user_idx)) != 0)) kw_args--;
         else {
           __Pyx_RaiseArgtupleInvalid("score", 0, 2, 3, 1); __PYX_ERR(0, 173, __pyx_L3_error)
         }
         CYTHON_FALLTHROUGH;
         case  2:
         if (kw_args > 0) {
-          PyObject* value = __Pyx_PyDict_GetItemStr(__pyx_kwds, __pyx_n_s_item_id);
+          PyObject* value = __Pyx_PyDict_GetItemStr(__pyx_kwds, __pyx_n_s_item_idx);
           if (value) { values[2] = value; kw_args--; }
         }
       }
@@ -9857,8 +9857,8 @@ static PyObject *__pyx_pw_6cornac_6models_13baseline_only_8recom_bo_12BaselineOn
       }
     }
     __pyx_v_self = values[0];
-    __pyx_v_user_id = values[1];
-    __pyx_v_item_id = values[2];
+    __pyx_v_user_idx = values[1];
+    __pyx_v_item_idx = values[2];
   }
   goto __pyx_L4_argument_unpacking_done;
   __pyx_L5_argtuple_error:;
@@ -9868,14 +9868,14 @@ static PyObject *__pyx_pw_6cornac_6models_13baseline_only_8recom_bo_12BaselineOn
   __Pyx_RefNannyFinishContext();
   return NULL;
   __pyx_L4_argument_unpacking_done:;
-  __pyx_r = __pyx_pf_6cornac_6models_13baseline_only_8recom_bo_12BaselineOnly_6score(__pyx_self, __pyx_v_self, __pyx_v_user_id, __pyx_v_item_id);
+  __pyx_r = __pyx_pf_6cornac_6models_13baseline_only_8recom_bo_12BaselineOnly_6score(__pyx_self, __pyx_v_self, __pyx_v_user_idx, __pyx_v_item_idx);
 
   /* function exit code */
   __Pyx_RefNannyFinishContext();
   return __pyx_r;
 }
 
-static PyObject *__pyx_pf_6cornac_6models_13baseline_only_8recom_bo_12BaselineOnly_6score(CYTHON_UNUSED PyObject *__pyx_self, PyObject *__pyx_v_self, PyObject *__pyx_v_user_id, PyObject *__pyx_v_item_id) {
+static PyObject *__pyx_pf_6cornac_6models_13baseline_only_8recom_bo_12BaselineOnly_6score(CYTHON_UNUSED PyObject *__pyx_self, PyObject *__pyx_v_self, PyObject *__pyx_v_user_idx, PyObject *__pyx_v_item_idx) {
   PyObject *__pyx_v_unk_user = NULL;
   PyObject *__pyx_v_known_item_scores = NULL;
   PyObject *__pyx_v_unk_item = NULL;
@@ -9896,9 +9896,9 @@ static PyObject *__pyx_pf_6cornac_6models_13baseline_only_8recom_bo_12BaselineOn
   /* "cornac/models/baseline_only/recom_bo.pyx":191
  * 
  *         """
- *         unk_user = self.train_set.is_unk_user(user_id)             # <<<<<<<<<<<<<<
+ *         unk_user = self.train_set.is_unk_user(user_idx)             # <<<<<<<<<<<<<<
  * 
- *         if item_id is None:
+ *         if item_idx is None:
  */
   __pyx_t_2 = __Pyx_PyObject_GetAttrStr(__pyx_v_self, __pyx_n_s_train_set); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 191, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_2);
@@ -9915,7 +9915,7 @@ static PyObject *__pyx_pf_6cornac_6models_13baseline_only_8recom_bo_12BaselineOn
       __Pyx_DECREF_SET(__pyx_t_3, function);
     }
   }
-  __pyx_t_1 = (__pyx_t_2) ? __Pyx_PyObject_Call2Args(__pyx_t_3, __pyx_t_2, __pyx_v_user_id) : __Pyx_PyObject_CallOneArg(__pyx_t_3, __pyx_v_user_id);
+  __pyx_t_1 = (__pyx_t_2) ? __Pyx_PyObject_Call2Args(__pyx_t_3, __pyx_t_2, __pyx_v_user_idx) : __Pyx_PyObject_CallOneArg(__pyx_t_3, __pyx_v_user_idx);
   __Pyx_XDECREF(__pyx_t_2); __pyx_t_2 = 0;
   if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 191, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
@@ -9924,22 +9924,22 @@ static PyObject *__pyx_pf_6cornac_6models_13baseline_only_8recom_bo_12BaselineOn
   __pyx_t_1 = 0;
 
   /* "cornac/models/baseline_only/recom_bo.pyx":193
- *         unk_user = self.train_set.is_unk_user(user_id)
+ *         unk_user = self.train_set.is_unk_user(user_idx)
  * 
- *         if item_id is None:             # <<<<<<<<<<<<<<
+ *         if item_idx is None:             # <<<<<<<<<<<<<<
  *             known_item_scores = np.add(self.i_biases, self.global_mean)
  *             if not unk_user:
  */
-  __pyx_t_4 = (__pyx_v_item_id == Py_None);
+  __pyx_t_4 = (__pyx_v_item_idx == Py_None);
   __pyx_t_5 = (__pyx_t_4 != 0);
   if (__pyx_t_5) {
 
     /* "cornac/models/baseline_only/recom_bo.pyx":194
  * 
- *         if item_id is None:
+ *         if item_idx is None:
  *             known_item_scores = np.add(self.i_biases, self.global_mean)             # <<<<<<<<<<<<<<
  *             if not unk_user:
- *                 known_item_scores = np.add(known_item_scores, self.u_biases[user_id])
+ *                 known_item_scores = np.add(known_item_scores, self.u_biases[user_idx])
  */
     __Pyx_GetModuleGlobalName(__pyx_t_3, __pyx_n_s_np); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 194, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_3);
@@ -10003,10 +10003,10 @@ static PyObject *__pyx_pf_6cornac_6models_13baseline_only_8recom_bo_12BaselineOn
     __pyx_t_1 = 0;
 
     /* "cornac/models/baseline_only/recom_bo.pyx":195
- *         if item_id is None:
+ *         if item_idx is None:
  *             known_item_scores = np.add(self.i_biases, self.global_mean)
  *             if not unk_user:             # <<<<<<<<<<<<<<
- *                 known_item_scores = np.add(known_item_scores, self.u_biases[user_id])
+ *                 known_item_scores = np.add(known_item_scores, self.u_biases[user_idx])
  *             return known_item_scores
  */
     __pyx_t_5 = __Pyx_PyObject_IsTrue(__pyx_v_unk_user); if (unlikely(__pyx_t_5 < 0)) __PYX_ERR(0, 195, __pyx_L1_error)
@@ -10016,7 +10016,7 @@ static PyObject *__pyx_pf_6cornac_6models_13baseline_only_8recom_bo_12BaselineOn
       /* "cornac/models/baseline_only/recom_bo.pyx":196
  *             known_item_scores = np.add(self.i_biases, self.global_mean)
  *             if not unk_user:
- *                 known_item_scores = np.add(known_item_scores, self.u_biases[user_id])             # <<<<<<<<<<<<<<
+ *                 known_item_scores = np.add(known_item_scores, self.u_biases[user_idx])             # <<<<<<<<<<<<<<
  *             return known_item_scores
  *         else:
  */
@@ -10027,7 +10027,7 @@ static PyObject *__pyx_pf_6cornac_6models_13baseline_only_8recom_bo_12BaselineOn
       __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
       __pyx_t_2 = __Pyx_PyObject_GetAttrStr(__pyx_v_self, __pyx_n_s_u_biases); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 196, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_2);
-      __pyx_t_6 = __Pyx_PyObject_GetItem(__pyx_t_2, __pyx_v_user_id); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 196, __pyx_L1_error)
+      __pyx_t_6 = __Pyx_PyObject_GetItem(__pyx_t_2, __pyx_v_user_idx); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 196, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_6);
       __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
       __pyx_t_2 = NULL;
@@ -10081,20 +10081,20 @@ static PyObject *__pyx_pf_6cornac_6models_13baseline_only_8recom_bo_12BaselineOn
       __pyx_t_1 = 0;
 
       /* "cornac/models/baseline_only/recom_bo.pyx":195
- *         if item_id is None:
+ *         if item_idx is None:
  *             known_item_scores = np.add(self.i_biases, self.global_mean)
  *             if not unk_user:             # <<<<<<<<<<<<<<
- *                 known_item_scores = np.add(known_item_scores, self.u_biases[user_id])
+ *                 known_item_scores = np.add(known_item_scores, self.u_biases[user_idx])
  *             return known_item_scores
  */
     }
 
     /* "cornac/models/baseline_only/recom_bo.pyx":197
  *             if not unk_user:
- *                 known_item_scores = np.add(known_item_scores, self.u_biases[user_id])
+ *                 known_item_scores = np.add(known_item_scores, self.u_biases[user_idx])
  *             return known_item_scores             # <<<<<<<<<<<<<<
  *         else:
- *             unk_item = self.train_set.is_unk_item(item_id)
+ *             unk_item = self.train_set.is_unk_item(item_idx)
  */
     __Pyx_XDECREF(__pyx_r);
     __Pyx_INCREF(__pyx_v_known_item_scores);
@@ -10102,9 +10102,9 @@ static PyObject *__pyx_pf_6cornac_6models_13baseline_only_8recom_bo_12BaselineOn
     goto __pyx_L0;
 
     /* "cornac/models/baseline_only/recom_bo.pyx":193
- *         unk_user = self.train_set.is_unk_user(user_id)
+ *         unk_user = self.train_set.is_unk_user(user_idx)
  * 
- *         if item_id is None:             # <<<<<<<<<<<<<<
+ *         if item_idx is None:             # <<<<<<<<<<<<<<
  *             known_item_scores = np.add(self.i_biases, self.global_mean)
  *             if not unk_user:
  */
@@ -10113,7 +10113,7 @@ static PyObject *__pyx_pf_6cornac_6models_13baseline_only_8recom_bo_12BaselineOn
   /* "cornac/models/baseline_only/recom_bo.pyx":199
  *             return known_item_scores
  *         else:
- *             unk_item = self.train_set.is_unk_item(item_id)             # <<<<<<<<<<<<<<
+ *             unk_item = self.train_set.is_unk_item(item_idx)             # <<<<<<<<<<<<<<
  *             item_score = self.global_mean
  *             if not unk_user:
  */
@@ -10133,7 +10133,7 @@ static PyObject *__pyx_pf_6cornac_6models_13baseline_only_8recom_bo_12BaselineOn
         __Pyx_DECREF_SET(__pyx_t_3, function);
       }
     }
-    __pyx_t_1 = (__pyx_t_9) ? __Pyx_PyObject_Call2Args(__pyx_t_3, __pyx_t_9, __pyx_v_item_id) : __Pyx_PyObject_CallOneArg(__pyx_t_3, __pyx_v_item_id);
+    __pyx_t_1 = (__pyx_t_9) ? __Pyx_PyObject_Call2Args(__pyx_t_3, __pyx_t_9, __pyx_v_item_idx) : __Pyx_PyObject_CallOneArg(__pyx_t_3, __pyx_v_item_idx);
     __Pyx_XDECREF(__pyx_t_9); __pyx_t_9 = 0;
     if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 199, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_1);
@@ -10143,10 +10143,10 @@ static PyObject *__pyx_pf_6cornac_6models_13baseline_only_8recom_bo_12BaselineOn
 
     /* "cornac/models/baseline_only/recom_bo.pyx":200
  *         else:
- *             unk_item = self.train_set.is_unk_item(item_id)
+ *             unk_item = self.train_set.is_unk_item(item_idx)
  *             item_score = self.global_mean             # <<<<<<<<<<<<<<
  *             if not unk_user:
- *                 item_score += self.u_biases[user_id]
+ *                 item_score += self.u_biases[user_idx]
  */
     __pyx_t_1 = __Pyx_PyObject_GetAttrStr(__pyx_v_self, __pyx_n_s_global_mean); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 200, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_1);
@@ -10154,10 +10154,10 @@ static PyObject *__pyx_pf_6cornac_6models_13baseline_only_8recom_bo_12BaselineOn
     __pyx_t_1 = 0;
 
     /* "cornac/models/baseline_only/recom_bo.pyx":201
- *             unk_item = self.train_set.is_unk_item(item_id)
+ *             unk_item = self.train_set.is_unk_item(item_idx)
  *             item_score = self.global_mean
  *             if not unk_user:             # <<<<<<<<<<<<<<
- *                 item_score += self.u_biases[user_id]
+ *                 item_score += self.u_biases[user_idx]
  *             if not unk_item:
  */
     __pyx_t_4 = __Pyx_PyObject_IsTrue(__pyx_v_unk_user); if (unlikely(__pyx_t_4 < 0)) __PYX_ERR(0, 201, __pyx_L1_error)
@@ -10167,13 +10167,13 @@ static PyObject *__pyx_pf_6cornac_6models_13baseline_only_8recom_bo_12BaselineOn
       /* "cornac/models/baseline_only/recom_bo.pyx":202
  *             item_score = self.global_mean
  *             if not unk_user:
- *                 item_score += self.u_biases[user_id]             # <<<<<<<<<<<<<<
+ *                 item_score += self.u_biases[user_idx]             # <<<<<<<<<<<<<<
  *             if not unk_item:
- *                 item_score += self.i_biases[item_id]
+ *                 item_score += self.i_biases[item_idx]
  */
       __pyx_t_1 = __Pyx_PyObject_GetAttrStr(__pyx_v_self, __pyx_n_s_u_biases); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 202, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_1);
-      __pyx_t_3 = __Pyx_PyObject_GetItem(__pyx_t_1, __pyx_v_user_id); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 202, __pyx_L1_error)
+      __pyx_t_3 = __Pyx_PyObject_GetItem(__pyx_t_1, __pyx_v_user_idx); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 202, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_3);
       __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
       __pyx_t_1 = PyNumber_InPlaceAdd(__pyx_v_item_score, __pyx_t_3); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 202, __pyx_L1_error)
@@ -10183,19 +10183,19 @@ static PyObject *__pyx_pf_6cornac_6models_13baseline_only_8recom_bo_12BaselineOn
       __pyx_t_1 = 0;
 
       /* "cornac/models/baseline_only/recom_bo.pyx":201
- *             unk_item = self.train_set.is_unk_item(item_id)
+ *             unk_item = self.train_set.is_unk_item(item_idx)
  *             item_score = self.global_mean
  *             if not unk_user:             # <<<<<<<<<<<<<<
- *                 item_score += self.u_biases[user_id]
+ *                 item_score += self.u_biases[user_idx]
  *             if not unk_item:
  */
     }
 
     /* "cornac/models/baseline_only/recom_bo.pyx":203
  *             if not unk_user:
- *                 item_score += self.u_biases[user_id]
+ *                 item_score += self.u_biases[user_idx]
  *             if not unk_item:             # <<<<<<<<<<<<<<
- *                 item_score += self.i_biases[item_id]
+ *                 item_score += self.i_biases[item_idx]
  *             return item_score
  */
     __pyx_t_5 = __Pyx_PyObject_IsTrue(__pyx_v_unk_item); if (unlikely(__pyx_t_5 < 0)) __PYX_ERR(0, 203, __pyx_L1_error)
@@ -10203,14 +10203,14 @@ static PyObject *__pyx_pf_6cornac_6models_13baseline_only_8recom_bo_12BaselineOn
     if (__pyx_t_4) {
 
       /* "cornac/models/baseline_only/recom_bo.pyx":204
- *                 item_score += self.u_biases[user_id]
+ *                 item_score += self.u_biases[user_idx]
  *             if not unk_item:
- *                 item_score += self.i_biases[item_id]             # <<<<<<<<<<<<<<
+ *                 item_score += self.i_biases[item_idx]             # <<<<<<<<<<<<<<
  *             return item_score
  */
       __pyx_t_1 = __Pyx_PyObject_GetAttrStr(__pyx_v_self, __pyx_n_s_i_biases); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 204, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_1);
-      __pyx_t_3 = __Pyx_PyObject_GetItem(__pyx_t_1, __pyx_v_item_id); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 204, __pyx_L1_error)
+      __pyx_t_3 = __Pyx_PyObject_GetItem(__pyx_t_1, __pyx_v_item_idx); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 204, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_3);
       __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
       __pyx_t_1 = PyNumber_InPlaceAdd(__pyx_v_item_score, __pyx_t_3); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 204, __pyx_L1_error)
@@ -10221,16 +10221,16 @@ static PyObject *__pyx_pf_6cornac_6models_13baseline_only_8recom_bo_12BaselineOn
 
       /* "cornac/models/baseline_only/recom_bo.pyx":203
  *             if not unk_user:
- *                 item_score += self.u_biases[user_id]
+ *                 item_score += self.u_biases[user_idx]
  *             if not unk_item:             # <<<<<<<<<<<<<<
- *                 item_score += self.i_biases[item_id]
+ *                 item_score += self.i_biases[item_idx]
  *             return item_score
  */
     }
 
     /* "cornac/models/baseline_only/recom_bo.pyx":205
  *             if not unk_item:
- *                 item_score += self.i_biases[item_id]
+ *                 item_score += self.i_biases[item_idx]
  *             return item_score             # <<<<<<<<<<<<<<
  */
     __Pyx_XDECREF(__pyx_r);
@@ -10242,7 +10242,7 @@ static PyObject *__pyx_pf_6cornac_6models_13baseline_only_8recom_bo_12BaselineOn
   /* "cornac/models/baseline_only/recom_bo.pyx":173
  * 
  * 
- *     def score(self, user_id, item_id=None):             # <<<<<<<<<<<<<<
+ *     def score(self, user_idx, item_idx=None):             # <<<<<<<<<<<<<<
  *         """Predict the scores/ratings of a user for an item.
  * 
  */
@@ -26276,7 +26276,7 @@ static __Pyx_StringTabEntry __pyx_string_tab[] = {
   {&__pyx_kp_s_int_float, __pyx_k_int_float, sizeof(__pyx_k_int_float), 0, 0, 1, 0},
   {&__pyx_n_s_is_unk_item, __pyx_k_is_unk_item, sizeof(__pyx_k_is_unk_item), 0, 0, 1, 1},
   {&__pyx_n_s_is_unk_user, __pyx_k_is_unk_user, sizeof(__pyx_k_is_unk_user), 0, 0, 1, 1},
-  {&__pyx_n_s_item_id, __pyx_k_item_id, sizeof(__pyx_k_item_id), 0, 0, 1, 1},
+  {&__pyx_n_s_item_idx, __pyx_k_item_idx, sizeof(__pyx_k_item_idx), 0, 0, 1, 1},
   {&__pyx_n_s_item_score, __pyx_k_item_score, sizeof(__pyx_k_item_score), 0, 0, 1, 1},
   {&__pyx_n_s_itemsize, __pyx_k_itemsize, sizeof(__pyx_k_itemsize), 0, 0, 1, 1},
   {&__pyx_kp_s_itemsize_0_for_cython_array, __pyx_k_itemsize_0_for_cython_array, sizeof(__pyx_k_itemsize_0_for_cython_array), 0, 0, 1, 0},
@@ -26381,7 +26381,7 @@ static __Pyx_StringTabEntry __pyx_string_tab[] = {
   {&__pyx_kp_u_unknown_dtype_code_in_numpy_pxd, __pyx_k_unknown_dtype_code_in_numpy_pxd, sizeof(__pyx_k_unknown_dtype_code_in_numpy_pxd), 0, 1, 0, 0},
   {&__pyx_n_s_unpack, __pyx_k_unpack, sizeof(__pyx_k_unpack), 0, 0, 1, 1},
   {&__pyx_n_s_update, __pyx_k_update, sizeof(__pyx_k_update), 0, 0, 1, 1},
-  {&__pyx_n_s_user_id, __pyx_k_user_id, sizeof(__pyx_k_user_id), 0, 0, 1, 1},
+  {&__pyx_n_s_user_idx, __pyx_k_user_idx, sizeof(__pyx_k_user_idx), 0, 0, 1, 1},
   {&__pyx_n_s_utils_init_utils, __pyx_k_utils_init_utils, sizeof(__pyx_k_utils_init_utils), 0, 0, 1, 1},
   {&__pyx_n_s_val, __pyx_k_val, sizeof(__pyx_k_val), 0, 0, 1, 1},
   {&__pyx_n_s_val_set, __pyx_k_val_set, sizeof(__pyx_k_val_set), 0, 0, 1, 1},
@@ -26750,11 +26750,11 @@ static CYTHON_SMALL_CODE int __Pyx_InitCachedConstants(void) {
   /* "cornac/models/baseline_only/recom_bo.pyx":173
  * 
  * 
- *     def score(self, user_id, item_id=None):             # <<<<<<<<<<<<<<
+ *     def score(self, user_idx, item_idx=None):             # <<<<<<<<<<<<<<
  *         """Predict the scores/ratings of a user for an item.
  * 
  */
-  __pyx_tuple__39 = PyTuple_Pack(7, __pyx_n_s_self, __pyx_n_s_user_id, __pyx_n_s_item_id, __pyx_n_s_unk_user, __pyx_n_s_known_item_scores, __pyx_n_s_unk_item, __pyx_n_s_item_score); if (unlikely(!__pyx_tuple__39)) __PYX_ERR(0, 173, __pyx_L1_error)
+  __pyx_tuple__39 = PyTuple_Pack(7, __pyx_n_s_self, __pyx_n_s_user_idx, __pyx_n_s_item_idx, __pyx_n_s_unk_user, __pyx_n_s_known_item_scores, __pyx_n_s_unk_item, __pyx_n_s_item_score); if (unlikely(!__pyx_tuple__39)) __PYX_ERR(0, 173, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_tuple__39);
   __Pyx_GIVEREF(__pyx_tuple__39);
   __pyx_codeobj__40 = (PyObject*)__Pyx_PyCode_New(3, 0, 7, 0, CO_OPTIMIZED|CO_NEWLOCALS, __pyx_empty_bytes, __pyx_empty_tuple, __pyx_empty_tuple, __pyx_tuple__39, __pyx_empty_tuple, __pyx_empty_tuple, __pyx_kp_s_cornac_models_baseline_only_reco_2, __pyx_n_s_score, 173, __pyx_empty_bytes); if (unlikely(!__pyx_codeobj__40)) __PYX_ERR(0, 173, __pyx_L1_error)
@@ -27337,7 +27337,7 @@ if (!__Pyx_RefNanny) {
   /* "cornac/models/baseline_only/recom_bo.pyx":173
  * 
  * 
- *     def score(self, user_id, item_id=None):             # <<<<<<<<<<<<<<
+ *     def score(self, user_idx, item_idx=None):             # <<<<<<<<<<<<<<
  *         """Predict the scores/ratings of a user for an item.
  * 
  */

--- a/cornac/models/baseline_only/recom_bo.pyx
+++ b/cornac/models/baseline_only/recom_bo.pyx
@@ -170,15 +170,15 @@ class BaselineOnly(Recommender):
             print('Optimization finished!')
 
 
-    def score(self, user_id, item_id=None):
+    def score(self, user_idx, item_idx=None):
         """Predict the scores/ratings of a user for an item.
 
         Parameters
         ----------
-        user_id: int, required
+        user_idx: int, required
             The index of the user for whom to perform score prediction.
 
-        item_id: int, optional, default: None
+        item_idx: int, optional, default: None
             The index of the item for that to perform score prediction.
             If None, scores for all known items will be returned.
 
@@ -188,18 +188,18 @@ class BaselineOnly(Recommender):
             Relative scores that the user gives to the item or to all known items
 
         """
-        unk_user = self.train_set.is_unk_user(user_id)
+        unk_user = self.train_set.is_unk_user(user_idx)
 
-        if item_id is None:
+        if item_idx is None:
             known_item_scores = np.add(self.i_biases, self.global_mean)
             if not unk_user:
-                known_item_scores = np.add(known_item_scores, self.u_biases[user_id])
+                known_item_scores = np.add(known_item_scores, self.u_biases[user_idx])
             return known_item_scores
         else:
-            unk_item = self.train_set.is_unk_item(item_id)
+            unk_item = self.train_set.is_unk_item(item_idx)
             item_score = self.global_mean
             if not unk_user:
-                item_score += self.u_biases[user_id]
+                item_score += self.u_biases[user_idx]
             if not unk_item:
-                item_score += self.i_biases[item_id]
+                item_score += self.i_biases[item_idx]
             return item_score

--- a/cornac/models/baseline_only/recom_bo.pyx
+++ b/cornac/models/baseline_only/recom_bo.pyx
@@ -90,10 +90,10 @@ class BaselineOnly(Recommender):
 
         Parameters
         ----------
-        train_set: :obj:`cornac.data.MultimodalTrainSet`, required
+        train_set: :obj:`cornac.data.Dataset`, required
             User-Item preference data as well as additional modalities.
 
-        val_set: :obj:`cornac.data.MultimodalTestSet`, optional, default: None
+        val_set: :obj:`cornac.data.Dataset`, optional, default: None
             User-Item preference data for model selection purposes (e.g., early stopping).
 
         Returns

--- a/cornac/models/bpr/recom_bpr.cpp
+++ b/cornac/models/bpr/recom_bpr.cpp
@@ -2689,7 +2689,7 @@ static const char __pyx_k_fortran[] = "fortran";
 static const char __pyx_k_get_rng[] = "get_rng";
 static const char __pyx_k_i_index[] = "i_index";
 static const char __pyx_k_indices[] = "indices";
-static const char __pyx_k_item_id[] = "item_id";
+static const char __pyx_k_item_id[] = ", item_id=";
 static const char __pyx_k_j_index[] = "j_index";
 static const char __pyx_k_memview[] = "memview";
 static const char __pyx_k_n_items[] = "n_items";
@@ -2700,7 +2700,6 @@ static const char __pyx_k_rng_neg[] = "rng_neg";
 static const char __pyx_k_rng_pos[] = "rng_pos";
 static const char __pyx_k_skipped[] = "skipped";
 static const char __pyx_k_uniform[] = "uniform";
-static const char __pyx_k_user_id[] = "user_id";
 static const char __pyx_k_val_set[] = "val_set";
 static const char __pyx_k_verbose[] = "verbose";
 static const char __pyx_k_Ellipsis[] = "Ellipsis";
@@ -2709,6 +2708,7 @@ static const char __pyx_k_fast_dot[] = "fast_dot";
 static const char __pyx_k_getstate[] = "__getstate__";
 static const char __pyx_k_i_biases[] = "i_biases";
 static const char __pyx_k_item_ids[] = "item_ids";
+static const char __pyx_k_item_idx[] = "item_idx";
 static const char __pyx_k_itemsize[] = "itemsize";
 static const char __pyx_k_max_iter[] = "max_iter";
 static const char __pyx_k_progress[] = "progress";
@@ -2717,6 +2717,7 @@ static const char __pyx_k_qualname[] = "__qualname__";
 static const char __pyx_k_setstate[] = "__setstate__";
 static const char __pyx_k_unk_user[] = "unk_user";
 static const char __pyx_k_user_ids[] = "user_ids";
+static const char __pyx_k_user_idx[] = "user_idx";
 static const char __pyx_k_BPR_score[] = "BPR.score";
 static const char __pyx_k_RNGVector[] = "RNGVector";
 static const char __pyx_k_TypeError[] = "TypeError";
@@ -2725,7 +2726,6 @@ static const char __pyx_k_enumerate[] = "enumerate";
 static const char __pyx_k_exception[] = "exception";
 static const char __pyx_k_i_factors[] = "i_factors";
 static const char __pyx_k_int_float[] = "int|float";
-static const char __pyx_k_item_id_2[] = ", item_id=";
 static const char __pyx_k_metaclass[] = "__metaclass__";
 static const char __pyx_k_num_items[] = "num_items";
 static const char __pyx_k_num_users[] = "num_users";
@@ -2941,9 +2941,9 @@ static PyObject *__pyx_kp_s_int_float;
 static PyObject *__pyx_n_s_is_unk_item;
 static PyObject *__pyx_n_s_is_unk_user;
 static PyObject *__pyx_n_s_item_i;
-static PyObject *__pyx_n_s_item_id;
-static PyObject *__pyx_kp_u_item_id_2;
+static PyObject *__pyx_kp_u_item_id;
 static PyObject *__pyx_n_s_item_ids;
+static PyObject *__pyx_n_s_item_idx;
 static PyObject *__pyx_n_s_item_j;
 static PyObject *__pyx_n_s_item_score;
 static PyObject *__pyx_n_s_itemsize;
@@ -3060,8 +3060,8 @@ static PyObject *__pyx_n_s_unpack;
 static PyObject *__pyx_n_s_update;
 static PyObject *__pyx_n_s_user;
 static PyObject *__pyx_n_s_user_counts;
-static PyObject *__pyx_n_s_user_id;
 static PyObject *__pyx_n_s_user_ids;
+static PyObject *__pyx_n_s_user_idx;
 static PyObject *__pyx_n_s_utils;
 static PyObject *__pyx_n_s_utils_common;
 static PyObject *__pyx_n_s_utils_init_utils;
@@ -3081,7 +3081,7 @@ static PyObject *__pyx_pf_6cornac_6models_3bpr_9recom_bpr_3BPR_12_fit_sgd(CYTHON
 static PyObject *__pyx_pf_6cornac_6models_3bpr_9recom_bpr_3BPR_14_fit_sgd(CYTHON_UNUSED PyObject *__pyx_self, PyObject *__pyx_v_self, struct __pyx_obj_6cornac_6models_3bpr_9recom_bpr_RNGVector *__pyx_v_rng_pos, struct __pyx_obj_6cornac_6models_3bpr_9recom_bpr_RNGVector *__pyx_v_rng_neg, int __pyx_v_num_threads, __Pyx_memviewslice __pyx_v_user_ids, __Pyx_memviewslice __pyx_v_item_ids, __Pyx_memviewslice __pyx_v_indptr, __Pyx_memviewslice __pyx_v_U, __Pyx_memviewslice __pyx_v_V, __Pyx_memviewslice __pyx_v_B); /* proto */
 static PyObject *__pyx_pf_6cornac_6models_3bpr_9recom_bpr_3BPR_16_fit_sgd(CYTHON_UNUSED PyObject *__pyx_self, PyObject *__pyx_v_self, struct __pyx_obj_6cornac_6models_3bpr_9recom_bpr_RNGVector *__pyx_v_rng_pos, struct __pyx_obj_6cornac_6models_3bpr_9recom_bpr_RNGVector *__pyx_v_rng_neg, int __pyx_v_num_threads, __Pyx_memviewslice __pyx_v_user_ids, __Pyx_memviewslice __pyx_v_item_ids, __Pyx_memviewslice __pyx_v_indptr, __Pyx_memviewslice __pyx_v_U, __Pyx_memviewslice __pyx_v_V, __Pyx_memviewslice __pyx_v_B); /* proto */
 static PyObject *__pyx_pf_6cornac_6models_3bpr_9recom_bpr_3BPR_18_fit_sgd(CYTHON_UNUSED PyObject *__pyx_self, PyObject *__pyx_v_self, struct __pyx_obj_6cornac_6models_3bpr_9recom_bpr_RNGVector *__pyx_v_rng_pos, struct __pyx_obj_6cornac_6models_3bpr_9recom_bpr_RNGVector *__pyx_v_rng_neg, int __pyx_v_num_threads, __Pyx_memviewslice __pyx_v_user_ids, __Pyx_memviewslice __pyx_v_item_ids, __Pyx_memviewslice __pyx_v_indptr, __Pyx_memviewslice __pyx_v_U, __Pyx_memviewslice __pyx_v_V, __Pyx_memviewslice __pyx_v_B); /* proto */
-static PyObject *__pyx_pf_6cornac_6models_3bpr_9recom_bpr_3BPR_6score(CYTHON_UNUSED PyObject *__pyx_self, PyObject *__pyx_v_self, PyObject *__pyx_v_user_id, PyObject *__pyx_v_item_id); /* proto */
+static PyObject *__pyx_pf_6cornac_6models_3bpr_9recom_bpr_3BPR_6score(CYTHON_UNUSED PyObject *__pyx_self, PyObject *__pyx_v_self, PyObject *__pyx_v_user_idx, PyObject *__pyx_v_item_idx); /* proto */
 static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, Py_buffer *__pyx_v_info, int __pyx_v_flags); /* proto */
 static void __pyx_pf_5numpy_7ndarray_2__releasebuffer__(PyArrayObject *__pyx_v_self, Py_buffer *__pyx_v_info); /* proto */
 static int __pyx_array___pyx_pf_15View_dot_MemoryView_5array___cinit__(struct __pyx_array_obj *__pyx_v_self, PyObject *__pyx_v_shape, Py_ssize_t __pyx_v_itemsize, PyObject *__pyx_v_format, PyObject *__pyx_v_mode, int __pyx_v_allocate_buffer); /* proto */
@@ -4150,7 +4150,7 @@ static PyObject *__pyx_pf_6cornac_6models_3bpr_9recom_bpr_3BPR___init__(CYTHON_U
 
 /* Python wrapper */
 static PyObject *__pyx_pw_6cornac_6models_3bpr_9recom_bpr_3BPR_3fit(PyObject *__pyx_self, PyObject *__pyx_args, PyObject *__pyx_kwds); /*proto*/
-static char __pyx_doc_6cornac_6models_3bpr_9recom_bpr_3BPR_2fit[] = "Fit the model to observations.\n\n        Parameters\n        ----------\n        train_set: :obj:`cornac.data.MultimodalTrainSet`, required\n            User-Item preference data as well as additional modalities.\n\n        val_set: :obj:`cornac.data.MultimodalTestSet`, optional, default: None\n            User-Item preference data for model selection purposes (e.g., early stopping).\n\n        Returns\n        -------\n        self : object\n        ";
+static char __pyx_doc_6cornac_6models_3bpr_9recom_bpr_3BPR_2fit[] = "Fit the model to observations.\n\n        Parameters\n        ----------\n        train_set: :obj:`cornac.data.Dataset`, required\n            User-Item preference data as well as additional modalities.\n\n        val_set: :obj:`cornac.data.Dataset`, optional, default: None\n            User-Item preference data for model selection purposes (e.g., early stopping).\n\n        Returns\n        -------\n        self : object\n        ";
 static PyMethodDef __pyx_mdef_6cornac_6models_3bpr_9recom_bpr_3BPR_3fit = {"fit", (PyCFunction)(void*)(PyCFunctionWithKeywords)__pyx_pw_6cornac_6models_3bpr_9recom_bpr_3BPR_3fit, METH_VARARGS|METH_KEYWORDS, __pyx_doc_6cornac_6models_3bpr_9recom_bpr_3BPR_2fit};
 static PyObject *__pyx_pw_6cornac_6models_3bpr_9recom_bpr_3BPR_3fit(PyObject *__pyx_self, PyObject *__pyx_args, PyObject *__pyx_kwds) {
   PyObject *__pyx_v_self = 0;
@@ -10355,24 +10355,24 @@ static PyObject *__pyx_pf_6cornac_6models_3bpr_9recom_bpr_3BPR_18_fit_sgd(CYTHON
 /* "cornac/models/bpr/recom_bpr.pyx":232
  * 
  * 
- *     def score(self, user_id, item_id=None):             # <<<<<<<<<<<<<<
+ *     def score(self, user_idx, item_idx=None):             # <<<<<<<<<<<<<<
  *         """Predict the scores/ratings of a user for an item.
  * 
  */
 
 /* Python wrapper */
 static PyObject *__pyx_pw_6cornac_6models_3bpr_9recom_bpr_3BPR_7score(PyObject *__pyx_self, PyObject *__pyx_args, PyObject *__pyx_kwds); /*proto*/
-static char __pyx_doc_6cornac_6models_3bpr_9recom_bpr_3BPR_6score[] = "Predict the scores/ratings of a user for an item.\n\n        Parameters\n        ----------\n        user_id: int, required\n            The index of the user for whom to perform score prediction.\n\n        item_id: int, optional, default: None\n            The index of the item for that to perform score prediction.\n            If None, scores for all known items will be returned.\n\n        Returns\n        -------\n        res : A scalar or a Numpy array\n            Relative scores that the user gives to the item or to all known items\n\n        ";
+static char __pyx_doc_6cornac_6models_3bpr_9recom_bpr_3BPR_6score[] = "Predict the scores/ratings of a user for an item.\n\n        Parameters\n        ----------\n        user_idx: int, required\n            The index of the user for whom to perform score prediction.\n\n        item_idx: int, optional, default: None\n            The index of the item for that to perform score prediction.\n            If None, scores for all known items will be returned.\n\n        Returns\n        -------\n        res : A scalar or a Numpy array\n            Relative scores that the user gives to the item or to all known items\n\n        ";
 static PyMethodDef __pyx_mdef_6cornac_6models_3bpr_9recom_bpr_3BPR_7score = {"score", (PyCFunction)(void*)(PyCFunctionWithKeywords)__pyx_pw_6cornac_6models_3bpr_9recom_bpr_3BPR_7score, METH_VARARGS|METH_KEYWORDS, __pyx_doc_6cornac_6models_3bpr_9recom_bpr_3BPR_6score};
 static PyObject *__pyx_pw_6cornac_6models_3bpr_9recom_bpr_3BPR_7score(PyObject *__pyx_self, PyObject *__pyx_args, PyObject *__pyx_kwds) {
   PyObject *__pyx_v_self = 0;
-  PyObject *__pyx_v_user_id = 0;
-  PyObject *__pyx_v_item_id = 0;
+  PyObject *__pyx_v_user_idx = 0;
+  PyObject *__pyx_v_item_idx = 0;
   PyObject *__pyx_r = 0;
   __Pyx_RefNannyDeclarations
   __Pyx_RefNannySetupContext("score (wrapper)", 0);
   {
-    static PyObject **__pyx_pyargnames[] = {&__pyx_n_s_self,&__pyx_n_s_user_id,&__pyx_n_s_item_id,0};
+    static PyObject **__pyx_pyargnames[] = {&__pyx_n_s_self,&__pyx_n_s_user_idx,&__pyx_n_s_item_idx,0};
     PyObject* values[3] = {0,0,0};
     values[2] = ((PyObject *)((PyObject *)Py_None));
     if (unlikely(__pyx_kwds)) {
@@ -10395,14 +10395,14 @@ static PyObject *__pyx_pw_6cornac_6models_3bpr_9recom_bpr_3BPR_7score(PyObject *
         else goto __pyx_L5_argtuple_error;
         CYTHON_FALLTHROUGH;
         case  1:
-        if (likely((values[1] = __Pyx_PyDict_GetItemStr(__pyx_kwds, __pyx_n_s_user_id)) != 0)) kw_args--;
+        if (likely((values[1] = __Pyx_PyDict_GetItemStr(__pyx_kwds, __pyx_n_s_user_idx)) != 0)) kw_args--;
         else {
           __Pyx_RaiseArgtupleInvalid("score", 0, 2, 3, 1); __PYX_ERR(0, 232, __pyx_L3_error)
         }
         CYTHON_FALLTHROUGH;
         case  2:
         if (kw_args > 0) {
-          PyObject* value = __Pyx_PyDict_GetItemStr(__pyx_kwds, __pyx_n_s_item_id);
+          PyObject* value = __Pyx_PyDict_GetItemStr(__pyx_kwds, __pyx_n_s_item_idx);
           if (value) { values[2] = value; kw_args--; }
         }
       }
@@ -10420,8 +10420,8 @@ static PyObject *__pyx_pw_6cornac_6models_3bpr_9recom_bpr_3BPR_7score(PyObject *
       }
     }
     __pyx_v_self = values[0];
-    __pyx_v_user_id = values[1];
-    __pyx_v_item_id = values[2];
+    __pyx_v_user_idx = values[1];
+    __pyx_v_item_idx = values[2];
   }
   goto __pyx_L4_argument_unpacking_done;
   __pyx_L5_argtuple_error:;
@@ -10431,14 +10431,14 @@ static PyObject *__pyx_pw_6cornac_6models_3bpr_9recom_bpr_3BPR_7score(PyObject *
   __Pyx_RefNannyFinishContext();
   return NULL;
   __pyx_L4_argument_unpacking_done:;
-  __pyx_r = __pyx_pf_6cornac_6models_3bpr_9recom_bpr_3BPR_6score(__pyx_self, __pyx_v_self, __pyx_v_user_id, __pyx_v_item_id);
+  __pyx_r = __pyx_pf_6cornac_6models_3bpr_9recom_bpr_3BPR_6score(__pyx_self, __pyx_v_self, __pyx_v_user_idx, __pyx_v_item_idx);
 
   /* function exit code */
   __Pyx_RefNannyFinishContext();
   return __pyx_r;
 }
 
-static PyObject *__pyx_pf_6cornac_6models_3bpr_9recom_bpr_3BPR_6score(CYTHON_UNUSED PyObject *__pyx_self, PyObject *__pyx_v_self, PyObject *__pyx_v_user_id, PyObject *__pyx_v_item_id) {
+static PyObject *__pyx_pf_6cornac_6models_3bpr_9recom_bpr_3BPR_6score(CYTHON_UNUSED PyObject *__pyx_self, PyObject *__pyx_v_self, PyObject *__pyx_v_user_idx, PyObject *__pyx_v_item_idx) {
   PyObject *__pyx_v_unk_user = NULL;
   PyObject *__pyx_v_known_item_scores = NULL;
   PyObject *__pyx_v_item_score = NULL;
@@ -10460,9 +10460,9 @@ static PyObject *__pyx_pf_6cornac_6models_3bpr_9recom_bpr_3BPR_6score(CYTHON_UNU
   /* "cornac/models/bpr/recom_bpr.pyx":250
  * 
  *         """
- *         unk_user = self.train_set.is_unk_user(user_id)             # <<<<<<<<<<<<<<
+ *         unk_user = self.train_set.is_unk_user(user_idx)             # <<<<<<<<<<<<<<
  * 
- *         if item_id is None:
+ *         if item_idx is None:
  */
   __pyx_t_2 = __Pyx_PyObject_GetAttrStr(__pyx_v_self, __pyx_n_s_train_set); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 250, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_2);
@@ -10479,7 +10479,7 @@ static PyObject *__pyx_pf_6cornac_6models_3bpr_9recom_bpr_3BPR_6score(CYTHON_UNU
       __Pyx_DECREF_SET(__pyx_t_3, function);
     }
   }
-  __pyx_t_1 = (__pyx_t_2) ? __Pyx_PyObject_Call2Args(__pyx_t_3, __pyx_t_2, __pyx_v_user_id) : __Pyx_PyObject_CallOneArg(__pyx_t_3, __pyx_v_user_id);
+  __pyx_t_1 = (__pyx_t_2) ? __Pyx_PyObject_Call2Args(__pyx_t_3, __pyx_t_2, __pyx_v_user_idx) : __Pyx_PyObject_CallOneArg(__pyx_t_3, __pyx_v_user_idx);
   __Pyx_XDECREF(__pyx_t_2); __pyx_t_2 = 0;
   if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 250, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
@@ -10488,22 +10488,22 @@ static PyObject *__pyx_pf_6cornac_6models_3bpr_9recom_bpr_3BPR_6score(CYTHON_UNU
   __pyx_t_1 = 0;
 
   /* "cornac/models/bpr/recom_bpr.pyx":252
- *         unk_user = self.train_set.is_unk_user(user_id)
+ *         unk_user = self.train_set.is_unk_user(user_idx)
  * 
- *         if item_id is None:             # <<<<<<<<<<<<<<
+ *         if item_idx is None:             # <<<<<<<<<<<<<<
  *             known_item_scores = np.copy(self.i_biases)
  *             if not unk_user:
  */
-  __pyx_t_4 = (__pyx_v_item_id == Py_None);
+  __pyx_t_4 = (__pyx_v_item_idx == Py_None);
   __pyx_t_5 = (__pyx_t_4 != 0);
   if (__pyx_t_5) {
 
     /* "cornac/models/bpr/recom_bpr.pyx":253
  * 
- *         if item_id is None:
+ *         if item_idx is None:
  *             known_item_scores = np.copy(self.i_biases)             # <<<<<<<<<<<<<<
  *             if not unk_user:
- *                 fast_dot(self.u_factors[user_id], self.i_factors, known_item_scores)
+ *                 fast_dot(self.u_factors[user_idx], self.i_factors, known_item_scores)
  */
     __Pyx_GetModuleGlobalName(__pyx_t_3, __pyx_n_s_np); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 253, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_3);
@@ -10532,10 +10532,10 @@ static PyObject *__pyx_pf_6cornac_6models_3bpr_9recom_bpr_3BPR_6score(CYTHON_UNU
     __pyx_t_1 = 0;
 
     /* "cornac/models/bpr/recom_bpr.pyx":254
- *         if item_id is None:
+ *         if item_idx is None:
  *             known_item_scores = np.copy(self.i_biases)
  *             if not unk_user:             # <<<<<<<<<<<<<<
- *                 fast_dot(self.u_factors[user_id], self.i_factors, known_item_scores)
+ *                 fast_dot(self.u_factors[user_idx], self.i_factors, known_item_scores)
  *             return known_item_scores
  */
     __pyx_t_5 = __Pyx_PyObject_IsTrue(__pyx_v_unk_user); if (unlikely(__pyx_t_5 < 0)) __PYX_ERR(0, 254, __pyx_L1_error)
@@ -10545,7 +10545,7 @@ static PyObject *__pyx_pf_6cornac_6models_3bpr_9recom_bpr_3BPR_6score(CYTHON_UNU
       /* "cornac/models/bpr/recom_bpr.pyx":255
  *             known_item_scores = np.copy(self.i_biases)
  *             if not unk_user:
- *                 fast_dot(self.u_factors[user_id], self.i_factors, known_item_scores)             # <<<<<<<<<<<<<<
+ *                 fast_dot(self.u_factors[user_idx], self.i_factors, known_item_scores)             # <<<<<<<<<<<<<<
  *             return known_item_scores
  *         else:
  */
@@ -10553,7 +10553,7 @@ static PyObject *__pyx_pf_6cornac_6models_3bpr_9recom_bpr_3BPR_6score(CYTHON_UNU
       __Pyx_GOTREF(__pyx_t_2);
       __pyx_t_3 = __Pyx_PyObject_GetAttrStr(__pyx_v_self, __pyx_n_s_u_factors); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 255, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_3);
-      __pyx_t_6 = __Pyx_PyObject_GetItem(__pyx_t_3, __pyx_v_user_id); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 255, __pyx_L1_error)
+      __pyx_t_6 = __Pyx_PyObject_GetItem(__pyx_t_3, __pyx_v_user_idx); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 255, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_6);
       __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
       __pyx_t_3 = __Pyx_PyObject_GetAttrStr(__pyx_v_self, __pyx_n_s_i_factors); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 255, __pyx_L1_error)
@@ -10613,20 +10613,20 @@ static PyObject *__pyx_pf_6cornac_6models_3bpr_9recom_bpr_3BPR_6score(CYTHON_UNU
       __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
 
       /* "cornac/models/bpr/recom_bpr.pyx":254
- *         if item_id is None:
+ *         if item_idx is None:
  *             known_item_scores = np.copy(self.i_biases)
  *             if not unk_user:             # <<<<<<<<<<<<<<
- *                 fast_dot(self.u_factors[user_id], self.i_factors, known_item_scores)
+ *                 fast_dot(self.u_factors[user_idx], self.i_factors, known_item_scores)
  *             return known_item_scores
  */
     }
 
     /* "cornac/models/bpr/recom_bpr.pyx":256
  *             if not unk_user:
- *                 fast_dot(self.u_factors[user_id], self.i_factors, known_item_scores)
+ *                 fast_dot(self.u_factors[user_idx], self.i_factors, known_item_scores)
  *             return known_item_scores             # <<<<<<<<<<<<<<
  *         else:
- *             if self.train_set.is_unk_item(item_id):
+ *             if self.train_set.is_unk_item(item_idx):
  */
     __Pyx_XDECREF(__pyx_r);
     __Pyx_INCREF(__pyx_v_known_item_scores);
@@ -10634,9 +10634,9 @@ static PyObject *__pyx_pf_6cornac_6models_3bpr_9recom_bpr_3BPR_6score(CYTHON_UNU
     goto __pyx_L0;
 
     /* "cornac/models/bpr/recom_bpr.pyx":252
- *         unk_user = self.train_set.is_unk_user(user_id)
+ *         unk_user = self.train_set.is_unk_user(user_idx)
  * 
- *         if item_id is None:             # <<<<<<<<<<<<<<
+ *         if item_idx is None:             # <<<<<<<<<<<<<<
  *             known_item_scores = np.copy(self.i_biases)
  *             if not unk_user:
  */
@@ -10645,9 +10645,9 @@ static PyObject *__pyx_pf_6cornac_6models_3bpr_9recom_bpr_3BPR_6score(CYTHON_UNU
   /* "cornac/models/bpr/recom_bpr.pyx":258
  *             return known_item_scores
  *         else:
- *             if self.train_set.is_unk_item(item_id):             # <<<<<<<<<<<<<<
- *                 raise ScoreException("Can't make score prediction for (user_id=%d, item_id=%d)" % (user_id, item_id))
- *             item_score = self.i_biases[item_id]
+ *             if self.train_set.is_unk_item(item_idx):             # <<<<<<<<<<<<<<
+ *                 raise ScoreException("Can't make score prediction for (user_id=%d, item_id=%d)" % (user_idx, item_idx))
+ *             item_score = self.i_biases[item_idx]
  */
   /*else*/ {
     __pyx_t_2 = __Pyx_PyObject_GetAttrStr(__pyx_v_self, __pyx_n_s_train_set); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 258, __pyx_L1_error)
@@ -10665,7 +10665,7 @@ static PyObject *__pyx_pf_6cornac_6models_3bpr_9recom_bpr_3BPR_6score(CYTHON_UNU
         __Pyx_DECREF_SET(__pyx_t_9, function);
       }
     }
-    __pyx_t_1 = (__pyx_t_2) ? __Pyx_PyObject_Call2Args(__pyx_t_9, __pyx_t_2, __pyx_v_item_id) : __Pyx_PyObject_CallOneArg(__pyx_t_9, __pyx_v_item_id);
+    __pyx_t_1 = (__pyx_t_2) ? __Pyx_PyObject_Call2Args(__pyx_t_9, __pyx_t_2, __pyx_v_item_idx) : __Pyx_PyObject_CallOneArg(__pyx_t_9, __pyx_v_item_idx);
     __Pyx_XDECREF(__pyx_t_2); __pyx_t_2 = 0;
     if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 258, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_1);
@@ -10676,9 +10676,9 @@ static PyObject *__pyx_pf_6cornac_6models_3bpr_9recom_bpr_3BPR_6score(CYTHON_UNU
 
       /* "cornac/models/bpr/recom_bpr.pyx":259
  *         else:
- *             if self.train_set.is_unk_item(item_id):
- *                 raise ScoreException("Can't make score prediction for (user_id=%d, item_id=%d)" % (user_id, item_id))             # <<<<<<<<<<<<<<
- *             item_score = self.i_biases[item_id]
+ *             if self.train_set.is_unk_item(item_idx):
+ *                 raise ScoreException("Can't make score prediction for (user_id=%d, item_id=%d)" % (user_idx, item_idx))             # <<<<<<<<<<<<<<
+ *             item_score = self.i_biases[item_idx]
  *             if not unk_user:
  */
       __Pyx_GetModuleGlobalName(__pyx_t_9, __pyx_n_s_ScoreException); if (unlikely(!__pyx_t_9)) __PYX_ERR(0, 259, __pyx_L1_error)
@@ -10691,18 +10691,18 @@ static PyObject *__pyx_pf_6cornac_6models_3bpr_9recom_bpr_3BPR_6score(CYTHON_UNU
       __pyx_t_10 += 41;
       __Pyx_GIVEREF(__pyx_kp_u_Can_t_make_score_prediction_for);
       PyTuple_SET_ITEM(__pyx_t_2, 0, __pyx_kp_u_Can_t_make_score_prediction_for);
-      __pyx_t_3 = __Pyx_PyObject_Format(__pyx_v_user_id, __pyx_n_u_d); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 259, __pyx_L1_error)
+      __pyx_t_3 = __Pyx_PyObject_Format(__pyx_v_user_idx, __pyx_n_u_d); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 259, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_3);
       __pyx_t_11 = (__Pyx_PyUnicode_MAX_CHAR_VALUE(__pyx_t_3) > __pyx_t_11) ? __Pyx_PyUnicode_MAX_CHAR_VALUE(__pyx_t_3) : __pyx_t_11;
       __pyx_t_10 += __Pyx_PyUnicode_GET_LENGTH(__pyx_t_3);
       __Pyx_GIVEREF(__pyx_t_3);
       PyTuple_SET_ITEM(__pyx_t_2, 1, __pyx_t_3);
       __pyx_t_3 = 0;
-      __Pyx_INCREF(__pyx_kp_u_item_id_2);
+      __Pyx_INCREF(__pyx_kp_u_item_id);
       __pyx_t_10 += 10;
-      __Pyx_GIVEREF(__pyx_kp_u_item_id_2);
-      PyTuple_SET_ITEM(__pyx_t_2, 2, __pyx_kp_u_item_id_2);
-      __pyx_t_3 = __Pyx_PyObject_Format(__pyx_v_item_id, __pyx_n_u_d); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 259, __pyx_L1_error)
+      __Pyx_GIVEREF(__pyx_kp_u_item_id);
+      PyTuple_SET_ITEM(__pyx_t_2, 2, __pyx_kp_u_item_id);
+      __pyx_t_3 = __Pyx_PyObject_Format(__pyx_v_item_idx, __pyx_n_u_d); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 259, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_3);
       __pyx_t_11 = (__Pyx_PyUnicode_MAX_CHAR_VALUE(__pyx_t_3) > __pyx_t_11) ? __Pyx_PyUnicode_MAX_CHAR_VALUE(__pyx_t_3) : __pyx_t_11;
       __pyx_t_10 += __Pyx_PyUnicode_GET_LENGTH(__pyx_t_3);
@@ -10739,32 +10739,32 @@ static PyObject *__pyx_pf_6cornac_6models_3bpr_9recom_bpr_3BPR_6score(CYTHON_UNU
       /* "cornac/models/bpr/recom_bpr.pyx":258
  *             return known_item_scores
  *         else:
- *             if self.train_set.is_unk_item(item_id):             # <<<<<<<<<<<<<<
- *                 raise ScoreException("Can't make score prediction for (user_id=%d, item_id=%d)" % (user_id, item_id))
- *             item_score = self.i_biases[item_id]
+ *             if self.train_set.is_unk_item(item_idx):             # <<<<<<<<<<<<<<
+ *                 raise ScoreException("Can't make score prediction for (user_id=%d, item_id=%d)" % (user_idx, item_idx))
+ *             item_score = self.i_biases[item_idx]
  */
     }
 
     /* "cornac/models/bpr/recom_bpr.pyx":260
- *             if self.train_set.is_unk_item(item_id):
- *                 raise ScoreException("Can't make score prediction for (user_id=%d, item_id=%d)" % (user_id, item_id))
- *             item_score = self.i_biases[item_id]             # <<<<<<<<<<<<<<
+ *             if self.train_set.is_unk_item(item_idx):
+ *                 raise ScoreException("Can't make score prediction for (user_id=%d, item_id=%d)" % (user_idx, item_idx))
+ *             item_score = self.i_biases[item_idx]             # <<<<<<<<<<<<<<
  *             if not unk_user:
- *                 item_score += np.dot(self.u_factors[user_id], self.i_factors[item_id])
+ *                 item_score += np.dot(self.u_factors[user_idx], self.i_factors[item_idx])
  */
     __pyx_t_1 = __Pyx_PyObject_GetAttrStr(__pyx_v_self, __pyx_n_s_i_biases); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 260, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_1);
-    __pyx_t_9 = __Pyx_PyObject_GetItem(__pyx_t_1, __pyx_v_item_id); if (unlikely(!__pyx_t_9)) __PYX_ERR(0, 260, __pyx_L1_error)
+    __pyx_t_9 = __Pyx_PyObject_GetItem(__pyx_t_1, __pyx_v_item_idx); if (unlikely(!__pyx_t_9)) __PYX_ERR(0, 260, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_9);
     __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
     __pyx_v_item_score = __pyx_t_9;
     __pyx_t_9 = 0;
 
     /* "cornac/models/bpr/recom_bpr.pyx":261
- *                 raise ScoreException("Can't make score prediction for (user_id=%d, item_id=%d)" % (user_id, item_id))
- *             item_score = self.i_biases[item_id]
+ *                 raise ScoreException("Can't make score prediction for (user_id=%d, item_id=%d)" % (user_idx, item_idx))
+ *             item_score = self.i_biases[item_idx]
  *             if not unk_user:             # <<<<<<<<<<<<<<
- *                 item_score += np.dot(self.u_factors[user_id], self.i_factors[item_id])
+ *                 item_score += np.dot(self.u_factors[user_idx], self.i_factors[item_idx])
  *             if self.train_set.min_rating != self.train_set.max_rating:
  */
     __pyx_t_4 = __Pyx_PyObject_IsTrue(__pyx_v_unk_user); if (unlikely(__pyx_t_4 < 0)) __PYX_ERR(0, 261, __pyx_L1_error)
@@ -10772,9 +10772,9 @@ static PyObject *__pyx_pf_6cornac_6models_3bpr_9recom_bpr_3BPR_6score(CYTHON_UNU
     if (__pyx_t_5) {
 
       /* "cornac/models/bpr/recom_bpr.pyx":262
- *             item_score = self.i_biases[item_id]
+ *             item_score = self.i_biases[item_idx]
  *             if not unk_user:
- *                 item_score += np.dot(self.u_factors[user_id], self.i_factors[item_id])             # <<<<<<<<<<<<<<
+ *                 item_score += np.dot(self.u_factors[user_idx], self.i_factors[item_idx])             # <<<<<<<<<<<<<<
  *             if self.train_set.min_rating != self.train_set.max_rating:
  *                 item_score = scale(item_score, self.train_set.min_rating, self.train_set.max_rating, 0., 1.)
  */
@@ -10785,12 +10785,12 @@ static PyObject *__pyx_pf_6cornac_6models_3bpr_9recom_bpr_3BPR_6score(CYTHON_UNU
       __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
       __pyx_t_1 = __Pyx_PyObject_GetAttrStr(__pyx_v_self, __pyx_n_s_u_factors); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 262, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_1);
-      __pyx_t_2 = __Pyx_PyObject_GetItem(__pyx_t_1, __pyx_v_user_id); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 262, __pyx_L1_error)
+      __pyx_t_2 = __Pyx_PyObject_GetItem(__pyx_t_1, __pyx_v_user_idx); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 262, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_2);
       __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
       __pyx_t_1 = __Pyx_PyObject_GetAttrStr(__pyx_v_self, __pyx_n_s_i_factors); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 262, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_1);
-      __pyx_t_6 = __Pyx_PyObject_GetItem(__pyx_t_1, __pyx_v_item_id); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 262, __pyx_L1_error)
+      __pyx_t_6 = __Pyx_PyObject_GetItem(__pyx_t_1, __pyx_v_item_idx); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 262, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_6);
       __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
       __pyx_t_1 = NULL;
@@ -10849,17 +10849,17 @@ static PyObject *__pyx_pf_6cornac_6models_3bpr_9recom_bpr_3BPR_6score(CYTHON_UNU
       __pyx_t_3 = 0;
 
       /* "cornac/models/bpr/recom_bpr.pyx":261
- *                 raise ScoreException("Can't make score prediction for (user_id=%d, item_id=%d)" % (user_id, item_id))
- *             item_score = self.i_biases[item_id]
+ *                 raise ScoreException("Can't make score prediction for (user_id=%d, item_id=%d)" % (user_idx, item_idx))
+ *             item_score = self.i_biases[item_idx]
  *             if not unk_user:             # <<<<<<<<<<<<<<
- *                 item_score += np.dot(self.u_factors[user_id], self.i_factors[item_id])
+ *                 item_score += np.dot(self.u_factors[user_idx], self.i_factors[item_idx])
  *             if self.train_set.min_rating != self.train_set.max_rating:
  */
     }
 
     /* "cornac/models/bpr/recom_bpr.pyx":263
  *             if not unk_user:
- *                 item_score += np.dot(self.u_factors[user_id], self.i_factors[item_id])
+ *                 item_score += np.dot(self.u_factors[user_idx], self.i_factors[item_idx])
  *             if self.train_set.min_rating != self.train_set.max_rating:             # <<<<<<<<<<<<<<
  *                 item_score = scale(item_score, self.train_set.min_rating, self.train_set.max_rating, 0., 1.)
  *             return item_score
@@ -10882,7 +10882,7 @@ static PyObject *__pyx_pf_6cornac_6models_3bpr_9recom_bpr_3BPR_6score(CYTHON_UNU
     if (__pyx_t_5) {
 
       /* "cornac/models/bpr/recom_bpr.pyx":264
- *                 item_score += np.dot(self.u_factors[user_id], self.i_factors[item_id])
+ *                 item_score += np.dot(self.u_factors[user_idx], self.i_factors[item_idx])
  *             if self.train_set.min_rating != self.train_set.max_rating:
  *                 item_score = scale(item_score, self.train_set.min_rating, self.train_set.max_rating, 0., 1.)             # <<<<<<<<<<<<<<
  *             return item_score
@@ -10962,7 +10962,7 @@ static PyObject *__pyx_pf_6cornac_6models_3bpr_9recom_bpr_3BPR_6score(CYTHON_UNU
 
       /* "cornac/models/bpr/recom_bpr.pyx":263
  *             if not unk_user:
- *                 item_score += np.dot(self.u_factors[user_id], self.i_factors[item_id])
+ *                 item_score += np.dot(self.u_factors[user_idx], self.i_factors[item_idx])
  *             if self.train_set.min_rating != self.train_set.max_rating:             # <<<<<<<<<<<<<<
  *                 item_score = scale(item_score, self.train_set.min_rating, self.train_set.max_rating, 0., 1.)
  *             return item_score
@@ -10983,7 +10983,7 @@ static PyObject *__pyx_pf_6cornac_6models_3bpr_9recom_bpr_3BPR_6score(CYTHON_UNU
   /* "cornac/models/bpr/recom_bpr.pyx":232
  * 
  * 
- *     def score(self, user_id, item_id=None):             # <<<<<<<<<<<<<<
+ *     def score(self, user_idx, item_idx=None):             # <<<<<<<<<<<<<<
  *         """Predict the scores/ratings of a user for an item.
  * 
  */
@@ -27127,9 +27127,9 @@ static __Pyx_StringTabEntry __pyx_string_tab[] = {
   {&__pyx_n_s_is_unk_item, __pyx_k_is_unk_item, sizeof(__pyx_k_is_unk_item), 0, 0, 1, 1},
   {&__pyx_n_s_is_unk_user, __pyx_k_is_unk_user, sizeof(__pyx_k_is_unk_user), 0, 0, 1, 1},
   {&__pyx_n_s_item_i, __pyx_k_item_i, sizeof(__pyx_k_item_i), 0, 0, 1, 1},
-  {&__pyx_n_s_item_id, __pyx_k_item_id, sizeof(__pyx_k_item_id), 0, 0, 1, 1},
-  {&__pyx_kp_u_item_id_2, __pyx_k_item_id_2, sizeof(__pyx_k_item_id_2), 0, 1, 0, 0},
+  {&__pyx_kp_u_item_id, __pyx_k_item_id, sizeof(__pyx_k_item_id), 0, 1, 0, 0},
   {&__pyx_n_s_item_ids, __pyx_k_item_ids, sizeof(__pyx_k_item_ids), 0, 0, 1, 1},
+  {&__pyx_n_s_item_idx, __pyx_k_item_idx, sizeof(__pyx_k_item_idx), 0, 0, 1, 1},
   {&__pyx_n_s_item_j, __pyx_k_item_j, sizeof(__pyx_k_item_j), 0, 0, 1, 1},
   {&__pyx_n_s_item_score, __pyx_k_item_score, sizeof(__pyx_k_item_score), 0, 0, 1, 1},
   {&__pyx_n_s_itemsize, __pyx_k_itemsize, sizeof(__pyx_k_itemsize), 0, 0, 1, 1},
@@ -27246,8 +27246,8 @@ static __Pyx_StringTabEntry __pyx_string_tab[] = {
   {&__pyx_n_s_update, __pyx_k_update, sizeof(__pyx_k_update), 0, 0, 1, 1},
   {&__pyx_n_s_user, __pyx_k_user, sizeof(__pyx_k_user), 0, 0, 1, 1},
   {&__pyx_n_s_user_counts, __pyx_k_user_counts, sizeof(__pyx_k_user_counts), 0, 0, 1, 1},
-  {&__pyx_n_s_user_id, __pyx_k_user_id, sizeof(__pyx_k_user_id), 0, 0, 1, 1},
   {&__pyx_n_s_user_ids, __pyx_k_user_ids, sizeof(__pyx_k_user_ids), 0, 0, 1, 1},
+  {&__pyx_n_s_user_idx, __pyx_k_user_idx, sizeof(__pyx_k_user_idx), 0, 0, 1, 1},
   {&__pyx_n_s_utils, __pyx_k_utils, sizeof(__pyx_k_utils), 0, 0, 1, 1},
   {&__pyx_n_s_utils_common, __pyx_k_utils_common, sizeof(__pyx_k_utils_common), 0, 0, 1, 1},
   {&__pyx_n_s_utils_init_utils, __pyx_k_utils_init_utils, sizeof(__pyx_k_utils_init_utils), 0, 0, 1, 1},
@@ -27648,11 +27648,11 @@ static CYTHON_SMALL_CODE int __Pyx_InitCachedConstants(void) {
   /* "cornac/models/bpr/recom_bpr.pyx":232
  * 
  * 
- *     def score(self, user_id, item_id=None):             # <<<<<<<<<<<<<<
+ *     def score(self, user_idx, item_idx=None):             # <<<<<<<<<<<<<<
  *         """Predict the scores/ratings of a user for an item.
  * 
  */
-  __pyx_tuple__43 = PyTuple_Pack(6, __pyx_n_s_self, __pyx_n_s_user_id, __pyx_n_s_item_id, __pyx_n_s_unk_user, __pyx_n_s_known_item_scores, __pyx_n_s_item_score); if (unlikely(!__pyx_tuple__43)) __PYX_ERR(0, 232, __pyx_L1_error)
+  __pyx_tuple__43 = PyTuple_Pack(6, __pyx_n_s_self, __pyx_n_s_user_idx, __pyx_n_s_item_idx, __pyx_n_s_unk_user, __pyx_n_s_known_item_scores, __pyx_n_s_item_score); if (unlikely(!__pyx_tuple__43)) __PYX_ERR(0, 232, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_tuple__43);
   __Pyx_GIVEREF(__pyx_tuple__43);
   __pyx_codeobj__44 = (PyObject*)__Pyx_PyCode_New(3, 0, 6, 0, CO_OPTIMIZED|CO_NEWLOCALS, __pyx_empty_bytes, __pyx_empty_tuple, __pyx_empty_tuple, __pyx_tuple__43, __pyx_empty_tuple, __pyx_empty_tuple, __pyx_kp_s_cornac_models_bpr_recom_bpr_pyx, __pyx_n_s_score, 232, __pyx_empty_bytes); if (unlikely(!__pyx_codeobj__44)) __PYX_ERR(0, 232, __pyx_L1_error)
@@ -28341,7 +28341,7 @@ if (!__Pyx_RefNanny) {
   /* "cornac/models/bpr/recom_bpr.pyx":232
  * 
  * 
- *     def score(self, user_id, item_id=None):             # <<<<<<<<<<<<<<
+ *     def score(self, user_idx, item_idx=None):             # <<<<<<<<<<<<<<
  *         """Predict the scores/ratings of a user for an item.
  * 
  */

--- a/cornac/models/bpr/recom_bpr.pyx
+++ b/cornac/models/bpr/recom_bpr.pyx
@@ -119,10 +119,10 @@ class BPR(Recommender):
 
         Parameters
         ----------
-        train_set: :obj:`cornac.data.MultimodalTrainSet`, required
+        train_set: :obj:`cornac.data.Dataset`, required
             User-Item preference data as well as additional modalities.
 
-        val_set: :obj:`cornac.data.MultimodalTestSet`, optional, default: None
+        val_set: :obj:`cornac.data.Dataset`, optional, default: None
             User-Item preference data for model selection purposes (e.g., early stopping).
 
         Returns

--- a/cornac/models/bpr/recom_bpr.pyx
+++ b/cornac/models/bpr/recom_bpr.pyx
@@ -229,15 +229,15 @@ class BPR(Recommender):
         return correct, skipped
 
 
-    def score(self, user_id, item_id=None):
+    def score(self, user_idx, item_idx=None):
         """Predict the scores/ratings of a user for an item.
 
         Parameters
         ----------
-        user_id: int, required
+        user_idx: int, required
             The index of the user for whom to perform score prediction.
 
-        item_id: int, optional, default: None
+        item_idx: int, optional, default: None
             The index of the item for that to perform score prediction.
             If None, scores for all known items will be returned.
 
@@ -247,19 +247,19 @@ class BPR(Recommender):
             Relative scores that the user gives to the item or to all known items
 
         """
-        unk_user = self.train_set.is_unk_user(user_id)
+        unk_user = self.train_set.is_unk_user(user_idx)
 
-        if item_id is None:
+        if item_idx is None:
             known_item_scores = np.copy(self.i_biases)
             if not unk_user:
-                fast_dot(self.u_factors[user_id], self.i_factors, known_item_scores)
+                fast_dot(self.u_factors[user_idx], self.i_factors, known_item_scores)
             return known_item_scores
         else:
-            if self.train_set.is_unk_item(item_id):
-                raise ScoreException("Can't make score prediction for (user_id=%d, item_id=%d)" % (user_id, item_id))
-            item_score = self.i_biases[item_id]
+            if self.train_set.is_unk_item(item_idx):
+                raise ScoreException("Can't make score prediction for (user_id=%d, item_id=%d)" % (user_idx, item_idx))
+            item_score = self.i_biases[item_idx]
             if not unk_user:
-                item_score += np.dot(self.u_factors[user_id], self.i_factors[item_id])
+                item_score += np.dot(self.u_factors[user_idx], self.i_factors[item_idx])
             if self.train_set.min_rating != self.train_set.max_rating:
                 item_score = scale(item_score, self.train_set.min_rating, self.train_set.max_rating, 0., 1.)
             return item_score

--- a/cornac/models/c2pf/recom_c2pf.py
+++ b/cornac/models/c2pf/recom_c2pf.py
@@ -148,15 +148,15 @@ class C2PF(Recommender):
 
         return self
 
-    def score(self, user_id, item_id=None):
+    def score(self, user_idx, item_idx=None):
         """Predict the scores/ratings of a user for an item.
 
         Parameters
         ----------
-        user_id: int, required
+        user_idx: int, required
             The index of the user for whom to perform score prediction.
 
-        item_id: int, optional, default: None
+        item_idx: int, optional, default: None
             The index of the item for that to perform score prediction.
             If None, scores for all known items will be returned.
 
@@ -167,20 +167,20 @@ class C2PF(Recommender):
 
         """
         if self.variant == 'c2pf' or self.variant == 'tc2pf':
-            if item_id is None:
-                user_pred = self.Beta * self.Theta[user_id, :].T + self.Xi * self.Theta[user_id, :].T
+            if item_idx is None:
+                user_pred = self.Beta * self.Theta[user_idx, :].T + self.Xi * self.Theta[user_idx, :].T
             else:
-                user_pred = self.Beta[item_id, :] * self.Theta[user_id, :].T + self.Xi * self.Theta[user_id, :].T
+                user_pred = self.Beta[item_idx, :] * self.Theta[user_idx, :].T + self.Xi * self.Theta[user_idx, :].T
         elif self.variant == 'rc2pf':
-            if item_id is None:
-                user_pred = self.Xi * self.Theta[user_id, :].T
+            if item_idx is None:
+                user_pred = self.Xi * self.Theta[user_idx, :].T
             else:
-                user_pred = self.Xi[item_id,] * self.Theta[user_id, :].T
+                user_pred = self.Xi[item_idx,] * self.Theta[user_idx, :].T
         else:
-            if item_id is None:
-                user_pred = self.Beta * self.Theta[user_id, :].T + self.Xi * self.Theta[user_id, :].T
+            if item_idx is None:
+                user_pred = self.Beta * self.Theta[user_idx, :].T + self.Xi * self.Theta[user_idx, :].T
             else:
-                user_pred = self.Beta[item_id, :] * self.Theta[user_id, :].T + self.Xi * self.Theta[user_id, :].T
+                user_pred = self.Beta[item_idx, :] * self.Theta[user_idx, :].T + self.Xi * self.Theta[user_idx, :].T
         # transform user_pred to a flatten array,
         user_pred = np.array(user_pred, dtype='float64').flatten()
 

--- a/cornac/models/c2pf/recom_c2pf.py
+++ b/cornac/models/c2pf/recom_c2pf.py
@@ -96,10 +96,10 @@ class C2PF(Recommender):
 
         Parameters
         ----------
-        train_set: :obj:`cornac.data.MultimodalTrainSet`, required
+        train_set: :obj:`cornac.data.Dataset`, required
             User-Item preference data as well as additional modalities.
 
-        val_set: :obj:`cornac.data.MultimodalTestSet`, optional, default: None
+        val_set: :obj:`cornac.data.Dataset`, optional, default: None
             User-Item preference data for model selection purposes (e.g., early stopping).
 
         Returns

--- a/cornac/models/cdl/recom_cdl.py
+++ b/cornac/models/cdl/recom_cdl.py
@@ -126,10 +126,10 @@ class CDL(Recommender):
 
         Parameters
         ----------
-        train_set: :obj:`cornac.data.MultimodalTrainSet`, required
+        train_set: :obj:`cornac.data.Dataset`, required
             User-Item preference data as well as additional modalities.
 
-        val_set: :obj:`cornac.data.MultimodalTestSet`, optional, default: None
+        val_set: :obj:`cornac.data.Dataset`, optional, default: None
             User-Item preference data for model selection purposes (e.g., early stopping).
 
         Returns

--- a/cornac/models/cdl/recom_cdl.py
+++ b/cornac/models/cdl/recom_cdl.py
@@ -208,15 +208,15 @@ class CDL(Recommender):
         if self.verbose:
             print('Learning completed!')
 
-    def score(self, user_id, item_id=None):
+    def score(self, user_idx, item_idx=None):
         """Predict the scores/ratings of a user for an item.
 
         Parameters
         ----------
-        user_id: int, required
+        user_idx: int, required
             The index of the user for whom to perform score prediction.
 
-        item_id: int, optional, default: None
+        item_idx: int, optional, default: None
             The index of the item for that to perform score prediction.
             If None, scores for all known items will be returned.
 
@@ -225,14 +225,14 @@ class CDL(Recommender):
         res : A scalar or a Numpy array
             Relative scores that the user gives to the item or to all known items
         """
-        if item_id is None:
-            if self.train_set.is_unk_user(user_id):
-                raise ScoreException("Can't make score prediction for (user_id=%d)" % user_id)
+        if item_idx is None:
+            if self.train_set.is_unk_user(user_idx):
+                raise ScoreException("Can't make score prediction for (user_id=%d)" % user_idx)
 
-            known_item_scores = self.V.dot(self.U[user_id, :])
+            known_item_scores = self.V.dot(self.U[user_idx, :])
             return known_item_scores
         else:
-            if self.train_set.is_unk_user(user_id) or self.train_set.is_unk_item(item_id):
-                raise ScoreException("Can't make score prediction for (user_id=%d, item_id=%d)" % (user_id, item_id))
-            user_pred = self.V[item_id, :].dot(self.U[user_id, :])
+            if self.train_set.is_unk_user(user_idx) or self.train_set.is_unk_item(item_idx):
+                raise ScoreException("Can't make score prediction for (user_id=%d, item_id=%d)" % (user_idx, item_idx))
+            user_pred = self.V[item_idx, :].dot(self.U[user_idx, :])
             return user_pred

--- a/cornac/models/cdr/recom_cdr.py
+++ b/cornac/models/cdr/recom_cdr.py
@@ -194,15 +194,15 @@ class CDR(Recommender):
         if self.verbose:
             print('\nLearning completed')
 
-    def score(self, user_id, item_id=None):
+    def score(self, user_idx, item_idx=None):
         """Predict the scores/ratings of a user for an item.
 
         Parameters
         ----------
-        user_id: int, required
+        user_idx: int, required
             The index of the user for whom to perform score prediction.
 
-        item_id: int, optional, default: None
+        item_idx: int, optional, default: None
             The index of the item for that to perform score prediction.
             If None, scores for all known items will be returned.
 
@@ -213,15 +213,15 @@ class CDR(Recommender):
 
         """
 
-        if item_id is None:
-            if self.train_set.is_unk_user(user_id):
-                raise ScoreException("Can't make score prediction for (user_id=%d)" % user_id)
+        if item_idx is None:
+            if self.train_set.is_unk_user(user_idx):
+                raise ScoreException("Can't make score prediction for (user_id=%d)" % user_idx)
 
-            known_item_scores = self.V.dot(self.U[user_id, :])
+            known_item_scores = self.V.dot(self.U[user_idx, :])
             return known_item_scores
         else:
-            if self.train_set.is_unk_user(user_id) or self.train_set.is_unk_item(item_id):
-                raise ScoreException("Can't make score prediction for (user_id=%d, item_id=%d)" % (user_id, item_id))
-            user_pred = self.V[item_id, :].dot(self.U[user_id, :])
+            if self.train_set.is_unk_user(user_idx) or self.train_set.is_unk_item(item_idx):
+                raise ScoreException("Can't make score prediction for (user_id=%d, item_id=%d)" % (user_idx, item_idx))
+            user_pred = self.V[item_idx, :].dot(self.U[user_idx, :])
 
             return user_pred

--- a/cornac/models/cdr/recom_cdr.py
+++ b/cornac/models/cdr/recom_cdr.py
@@ -113,10 +113,10 @@ class CDR(Recommender):
 
         Parameters
         ----------
-        train_set: :obj:`cornac.data.MultimodalTrainSet`, required
+        train_set: :obj:`cornac.data.Dataset`, required
             User-Item preference data as well as additional modalities.
 
-        val_set: :obj:`cornac.data.MultimodalTestSet`, optional, default: None
+        val_set: :obj:`cornac.data.Dataset`, optional, default: None
             User-Item preference data for model selection purposes (e.g., early stopping).
 
         Returns

--- a/cornac/models/cf/recom_cf.py
+++ b/cornac/models/cf/recom_cf.py
@@ -94,10 +94,10 @@ class CF(Recommender):
 
         Parameters
         ----------
-        train_set: :obj:`cornac.data.MultimodalTrainSet`, required
+        train_set: :obj:`cornac.data.Dataset`, required
             User-Item preference data as well as additional modalities.
 
-        val_set: :obj:`cornac.data.MultimodalTestSet`, optional, default: None
+        val_set: :obj:`cornac.data.Dataset`, optional, default: None
             User-Item preference data for model selection purposes (e.g., early stopping).
 
         Returns

--- a/cornac/models/cf/recom_cf.py
+++ b/cornac/models/cf/recom_cf.py
@@ -165,15 +165,15 @@ class CF(Recommender):
         if self.verbose:
             print('Learning completed!')
 
-    def score(self, user_id, item_id=None):
+    def score(self, user_idx, item_idx=None):
         """Predict the scores/ratings of a user for an item.
 
         Parameters
         ----------
-        user_id: int, required
+        user_idx: int, required
             The index of the user for whom to perform score prediction.
 
-        item_id: int, optional, default: None
+        item_idx: int, optional, default: None
             The index of the item for that to perform score prediction.
             If None, scores for all known items will be returned.
 
@@ -182,14 +182,14 @@ class CF(Recommender):
         res : A scalar or a Numpy array
             Relative scores that the user gives to the item or to all known items
         """
-        if item_id is None:
-            if self.train_set.is_unk_user(user_id):
-                raise ScoreException("Can't make score prediction for (user_id=%d)" % user_id)
+        if item_idx is None:
+            if self.train_set.is_unk_user(user_idx):
+                raise ScoreException("Can't make score prediction for (user_id=%d)" % user_idx)
 
-            known_item_scores = self.V.dot(self.U[user_id, :])
+            known_item_scores = self.V.dot(self.U[user_idx, :])
             return known_item_scores
         else:
-            if self.train_set.is_unk_user(user_id) or self.train_set.is_unk_item(item_id):
-                raise ScoreException("Can't make score prediction for (user_id=%d, item_id=%d)" % (user_id, item_id))
-            user_pred = self.V[item_id, :].dot(self.U[user_id, :])
+            if self.train_set.is_unk_user(user_idx) or self.train_set.is_unk_item(item_idx):
+                raise ScoreException("Can't make score prediction for (user_id=%d, item_id=%d)" % (user_idx, item_idx))
+            user_pred = self.V[item_idx, :].dot(self.U[user_idx, :])
             return user_pred

--- a/cornac/models/coe/recom_coe.py
+++ b/cornac/models/coe/recom_coe.py
@@ -84,10 +84,10 @@ class COE(Recommender):
 
         Parameters
         ----------
-        train_set: :obj:`cornac.data.MultimodalTrainSet`, required
+        train_set: :obj:`cornac.data.Dataset`, required
             User-Item preference data as well as additional modalities.
 
-        val_set: :obj:`cornac.data.MultimodalTestSet`, optional, default: None
+        val_set: :obj:`cornac.data.Dataset`, optional, default: None
             User-Item preference data for model selection purposes (e.g., early stopping).
 
         Returns

--- a/cornac/models/coe/recom_coe.py
+++ b/cornac/models/coe/recom_coe.py
@@ -115,15 +115,15 @@ class COE(Recommender):
     # get prefiction for a single user (predictions for one user at a time for efficiency purposes)
     # predictions are not stored for the same efficiency reasons"""
 
-    def score(self, user_id, item_id=None):
+    def score(self, user_idx, item_idx=None):
         """Predict the scores/ratings of a user for an item.
 
         Parameters
         ----------
-        user_id: int, required
+        user_idx: int, required
             The index of the user for whom to perform score prediction.
 
-        item_id: int, optional, default: None
+        item_idx: int, optional, default: None
             The index of the item for that to perform score prediction.
             If None, scores for all known items will be returned.
 
@@ -133,15 +133,15 @@ class COE(Recommender):
             Relative scores that the user gives to the item or to all known items
 
         """
-        if item_id is None:
-            if self.train_set.is_unk_user(user_id):
-                raise ScoreException("Can't make score prediction for (user_id=%d)" % user_id)
+        if item_idx is None:
+            if self.train_set.is_unk_user(user_idx):
+                raise ScoreException("Can't make score prediction for (user_id=%d)" % user_idx)
 
-            known_item_scores = np.sum(np.abs(self.V - self.U[user_id, :]) ** 2, axis=-1) ** (1. / 2)
+            known_item_scores = np.sum(np.abs(self.V - self.U[user_idx, :]) ** 2, axis=-1) ** (1. / 2)
             return known_item_scores
         else:
-            if self.train_set.is_unk_user(user_id) or self.train_set.is_unk_item(item_id):
-                raise ScoreException("Can't make score prediction for (user_id=%d, item_id=%d)" % (user_id, item_id))
+            if self.train_set.is_unk_user(user_idx) or self.train_set.is_unk_item(item_idx):
+                raise ScoreException("Can't make score prediction for (user_id=%d, item_id=%d)" % (user_idx, item_idx))
 
-            user_pred = np.sum(np.abs(self.V[item_id, :] - self.U[user_id, :]) ** 2, axis=-1) ** (1. / 2)
+            user_pred = np.sum(np.abs(self.V[item_idx, :] - self.U[user_idx, :]) ** 2, axis=-1) ** (1. / 2)
             return user_pred

--- a/cornac/models/conv_mf/recom_convmf.py
+++ b/cornac/models/conv_mf/recom_convmf.py
@@ -94,10 +94,10 @@ class ConvMF(Recommender):
 
         Parameters
         ----------
-        train_set: :obj:`cornac.data.MultimodalTrainSet`, required
+        train_set: :obj:`cornac.data.Dataset`, required
             User-Item preference data as well as additional modalities.
 
-        val_set: :obj:`cornac.data.MultimodalTestSet`, optional, default: None
+        val_set: :obj:`cornac.data.Dataset`, optional, default: None
             User-Item preference data for model selection purposes (e.g., early stopping).
 
         Returns

--- a/cornac/models/conv_mf/recom_convmf.py
+++ b/cornac/models/conv_mf/recom_convmf.py
@@ -231,15 +231,15 @@ class ConvMF(Recommender):
 
         tf.reset_default_graph()
 
-    def score(self, user_id, item_id=None):
+    def score(self, user_idx, item_idx=None):
         """Predict the scores/ratings of a user for an item.
 
         Parameters
         ----------
-        user_id: int, required
+        user_idx: int, required
             The index of the user for whom to perform score prediction.
 
-        item_id: int, optional, default: None
+        item_idx: int, optional, default: None
             The index of the item for that to perform score prediction.
             If None, scores for all known items will be returned.
 
@@ -249,16 +249,16 @@ class ConvMF(Recommender):
             Relative scores that the user gives to the item or to all known items
 
         """
-        if item_id is None:
-            if self.train_set.is_unk_user(user_id):
-                raise ScoreException("Can't make score prediction for (user_id=%d)" % user_id)
+        if item_idx is None:
+            if self.train_set.is_unk_user(user_idx):
+                raise ScoreException("Can't make score prediction for (user_id=%d)" % user_idx)
 
-            known_item_scores = self.V.dot(self.U[user_id, :])
+            known_item_scores = self.V.dot(self.U[user_idx, :])
             return known_item_scores
         else:
-            if self.train_set.is_unk_user(user_id) or self.train_set.is_unk_item(item_id):
-                raise ScoreException("Can't make score prediction for (user_id=%d, item_id=%d)" % (user_id, item_id))
+            if self.train_set.is_unk_user(user_idx) or self.train_set.is_unk_item(item_idx):
+                raise ScoreException("Can't make score prediction for (user_id=%d, item_id=%d)" % (user_idx, item_idx))
 
-            user_pred = self.V[item_id, :].dot(self.U[user_id, :])
+            user_pred = self.V[item_idx, :].dot(self.U[user_idx, :])
 
             return user_pred

--- a/cornac/models/ctr/recom_ctr.py
+++ b/cornac/models/ctr/recom_ctr.py
@@ -150,15 +150,15 @@ class CTR(Recommender):
         if self.verbose:
             print('Learning completed!')
 
-    def score(self, user_id, item_id=None):
+    def score(self, user_idx, item_idx=None):
         """Predict the scores/ratings of a user for an item.
 
         Parameters
         ----------
-        user_id: int, required
+        user_idx: int, required
             The index of the user for whom to perform score prediction.
 
-        item_id: int, optional, default: None
+        item_idx: int, optional, default: None
             The index of the item for that to perform score prediction.
             If None, scores for all known items will be returned.
 
@@ -167,14 +167,14 @@ class CTR(Recommender):
         res : A scalar or a Numpy array
             Relative scores that the user gives to the item or to all known items
         """
-        if item_id is None:
-            if self.train_set.is_unk_user(user_id):
-                raise ScoreException("Can't make score prediction for (user_id=%d)" % user_id)
+        if item_idx is None:
+            if self.train_set.is_unk_user(user_idx):
+                raise ScoreException("Can't make score prediction for (user_id=%d)" % user_idx)
 
-            known_item_scores = self.V.dot(self.U[user_id, :])
+            known_item_scores = self.V.dot(self.U[user_idx, :])
             return known_item_scores
         else:
-            if self.train_set.is_unk_user(user_id) or self.train_set.is_unk_item(item_id):
-                raise ScoreException("Can't make score prediction for (user_id=%d, item_id=%d)" % (user_id, item_id))
-            user_pred = self.V[item_id, :].dot(self.U[user_id, :])
+            if self.train_set.is_unk_user(user_idx) or self.train_set.is_unk_item(item_idx):
+                raise ScoreException("Can't make score prediction for (user_id=%d, item_id=%d)" % (user_idx, item_idx))
+            user_pred = self.V[item_idx, :].dot(self.U[user_idx, :])
             return user_pred

--- a/cornac/models/ctr/recom_ctr.py
+++ b/cornac/models/ctr/recom_ctr.py
@@ -90,10 +90,10 @@ class CTR(Recommender):
 
         Parameters
         ----------
-        train_set: :obj:`cornac.data.MultimodalTrainSet`, required
+        train_set: :obj:`cornac.data.Dataset`, required
             User-Item preference data as well as additional modalities.
 
-        val_set: :obj:`cornac.data.MultimodalTestSet`, optional, default: None
+        val_set: :obj:`cornac.data.Dataset`, optional, default: None
             User-Item preference data for model selection purposes (e.g., early stopping).
 
         Returns

--- a/cornac/models/cvae/recom_cvae.py
+++ b/cornac/models/cvae/recom_cvae.py
@@ -185,15 +185,15 @@ class CVAE(Recommender):
 
         tf.reset_default_graph()
 
-    def score(self, user_id, item_id=None):
+    def score(self, user_idx, item_idx=None):
         """Predict the scores/ratings of a user for an item.
 
         Parameters
         ----------
-        user_id: int, required
+        user_idx: int, required
             The index of the user for whom to perform score prediction.
 
-        item_id: int, optional, default: None
+        item_idx: int, optional, default: None
             The index of the item for that to perform score prediction.
             If None, scores for all known items will be returned.
 
@@ -203,16 +203,16 @@ class CVAE(Recommender):
             Relative scores that the user gives to the item or to all known items
 
         """
-        if item_id is None:
-            if self.train_set.is_unk_user(user_id):
-                raise ScoreException("Can't make score prediction for (user_id=%d)" % user_id)
+        if item_idx is None:
+            if self.train_set.is_unk_user(user_idx):
+                raise ScoreException("Can't make score prediction for (user_id=%d)" % user_idx)
 
-            known_item_scores = self.V.dot(self.U[user_id, :])
+            known_item_scores = self.V.dot(self.U[user_idx, :])
             return known_item_scores
         else:
-            if self.train_set.is_unk_user(user_id) or self.train_set.is_unk_item(item_id):
-                raise ScoreException("Can't make score prediction for (user_id=%d, item_id=%d)" % (user_id, item_id))
+            if self.train_set.is_unk_user(user_idx) or self.train_set.is_unk_item(item_idx):
+                raise ScoreException("Can't make score prediction for (user_id=%d, item_id=%d)" % (user_idx, item_idx))
 
-            user_pred = self.V[item_id, :].dot(self.U[user_id, :])
+            user_pred = self.V[item_idx, :].dot(self.U[user_idx, :])
 
             return user_pred

--- a/cornac/models/cvae/recom_cvae.py
+++ b/cornac/models/cvae/recom_cvae.py
@@ -114,10 +114,10 @@ class CVAE(Recommender):
 
         Parameters
         ----------
-        train_set: :obj:`cornac.data.MultimodalTrainSet`, required
+        train_set: :obj:`cornac.data.Dataset`, required
             User-Item preference data as well as additional modalities.
 
-        val_set: :obj:`cornac.data.MultimodalTestSet`, optional, default: None
+        val_set: :obj:`cornac.data.Dataset`, optional, default: None
             User-Item preference data for model selection purposes (e.g., early stopping).
 
         Returns

--- a/cornac/models/hft/recom_hft.py
+++ b/cornac/models/hft/recom_hft.py
@@ -163,15 +163,15 @@ class HFT(Recommender):
         if self.verbose:
             print('Learning completed!')
 
-    def score(self, user_id, item_id=None):
+    def score(self, user_idx, item_idx=None):
         """Predict the scores/ratings of a user for an item.
 
         Parameters
         ----------
-        user_id: int, required
+        user_idx: int, required
             The index of the user for whom to perform score prediction.
 
-        item_id: int, optional, default: None
+        item_idx: int, optional, default: None
             The index of the item for that to perform score prediction.
             If None, scores for all known items will be returned.
 
@@ -180,18 +180,18 @@ class HFT(Recommender):
         res : A scalar or a Numpy array
             Relative scores that the user gives to the item or to all known items
         """
-        if item_id is None:
-            if self.train_set.is_unk_user(user_id):
-                raise ScoreException("Can't make score prediction for (user_id=%d)" % user_id)
+        if item_idx is None:
+            if self.train_set.is_unk_user(user_idx):
+                raise ScoreException("Can't make score prediction for (user_id=%d)" % user_idx)
 
-            known_item_scores = self.alpha + self.beta_u[user_id] + self.beta_i + self.gamma_i.dot(
-                self.gamma_u[user_id, :])
+            known_item_scores = self.alpha + self.beta_u[user_idx] + self.beta_i + self.gamma_i.dot(
+                self.gamma_u[user_idx, :])
             return known_item_scores
         else:
-            if self.train_set.is_unk_user(user_id) or self.train_set.is_unk_item(item_id):
-                raise ScoreException("Can't make score prediction for (user_id=%d, item_id=%d)" % (user_id, item_id))
+            if self.train_set.is_unk_user(user_idx) or self.train_set.is_unk_item(item_idx):
+                raise ScoreException("Can't make score prediction for (user_id=%d, item_id=%d)" % (user_idx, item_idx))
 
-            user_pred = self.alpha + self.beta_u[user_id] + self.beta_i[item_id] + self.gamma_i[item_id, :].dot(
-                self.gamma_u[user_id, :])
+            user_pred = self.alpha + self.beta_u[user_idx] + self.beta_i[item_idx] + self.gamma_i[item_idx, :].dot(
+                self.gamma_u[user_idx, :])
 
             return user_pred

--- a/cornac/models/hft/recom_hft.py
+++ b/cornac/models/hft/recom_hft.py
@@ -97,10 +97,10 @@ class HFT(Recommender):
 
         Parameters
         ----------
-        train_set: :obj:`cornac.data.MultimodalTrainSet`, required
+        train_set: :obj:`cornac.data.Dataset`, required
             User-Item preference data as well as additional modalities.
 
-        val_set: :obj:`cornac.data.MultimodalTestSet`, optional, default: None
+        val_set: :obj:`cornac.data.Dataset`, optional, default: None
             User-Item preference data for model selection purposes (e.g., early stopping).
 
         Returns

--- a/cornac/models/hpf/recom_hpf.py
+++ b/cornac/models/hpf/recom_hpf.py
@@ -116,15 +116,15 @@ class HPF(Recommender):
 
         return self
 
-    def score(self, user_id, item_id=None):
+    def score(self, user_idx, item_idx=None):
         """Predict the scores/ratings of a user for an item.
 
         Parameters
         ----------
-        user_id: int, required
+        user_idx: int, required
             The index of the user for whom to perform score prediction.
 
-        item_id: int, optional, default: None
+        item_idx: int, optional, default: None
             The index of the item for that to perform score prediction.
             If None, scores for all known items will be returned.
 
@@ -134,20 +134,20 @@ class HPF(Recommender):
             Relative scores that the user gives to the item or to all known items
 
         """
-        if item_id is None:
-            if self.train_set.is_unk_user(user_id):
+        if item_idx is None:
+            if self.train_set.is_unk_user(user_idx):
                 u_representation = np.ones(self.k)
             else:
-                u_representation = self.Theta[user_id, :]
+                u_representation = self.Theta[user_idx, :]
 
             known_item_scores = self.Beta.dot(u_representation)
             known_item_scores = np.array(known_item_scores, dtype='float64').flatten()
             return known_item_scores
         else:
-            if self.train_set.is_unk_user(user_id) or self.train_set.is_unk_item(item_id):
-                raise ScoreException("Can't make score prediction for (user_id=%d, item_id=%d)" % (user_id, item_id))
+            if self.train_set.is_unk_user(user_idx) or self.train_set.is_unk_item(item_idx):
+                raise ScoreException("Can't make score prediction for (user_id=%d, item_id=%d)" % (user_idx, item_idx))
 
-            user_pred = self.Beta[item_id, :].dot(self.Theta[user_id, :])
+            user_pred = self.Beta[item_idx, :].dot(self.Theta[user_idx, :])
             user_pred = np.array(user_pred, dtype='float64').flatten()[0]
 
             return user_pred

--- a/cornac/models/hpf/recom_hpf.py
+++ b/cornac/models/hpf/recom_hpf.py
@@ -83,10 +83,10 @@ class HPF(Recommender):
 
         Parameters
         ----------
-        train_set: :obj:`cornac.data.MultimodalTrainSet`, required
+        train_set: :obj:`cornac.data.Dataset`, required
             User-Item preference data as well as additional modalities.
 
-        val_set: :obj:`cornac.data.MultimodalTestSet`, optional, default: None
+        val_set: :obj:`cornac.data.Dataset`, optional, default: None
             User-Item preference data for model selection purposes (e.g., early stopping).
 
         Returns

--- a/cornac/models/ibpr/recom_ibpr.py
+++ b/cornac/models/ibpr/recom_ibpr.py
@@ -84,10 +84,10 @@ class IBPR(Recommender):
 
         Parameters
         ----------
-        train_set: :obj:`cornac.data.MultimodalTrainSet`, required
+        train_set: :obj:`cornac.data.Dataset`, required
             User-Item preference data as well as additional modalities.
 
-        val_set: :obj:`cornac.data.MultimodalTestSet`, optional, default: None
+        val_set: :obj:`cornac.data.Dataset`, optional, default: None
             User-Item preference data for model selection purposes (e.g., early stopping).
 
         Returns

--- a/cornac/models/ibpr/recom_ibpr.py
+++ b/cornac/models/ibpr/recom_ibpr.py
@@ -119,15 +119,15 @@ class IBPR(Recommender):
 
         return self
 
-    def score(self, user_id, item_id=None):
+    def score(self, user_idx, item_idx=None):
         """Predict the scores/ratings of a user for an item.
 
         Parameters
         ----------
-        user_id: int, required
+        user_idx: int, required
             The index of the user for whom to perform score prediction.
 
-        item_id: int, optional, default: None
+        item_idx: int, optional, default: None
             The index of the item for that to perform score prediction.
             If None, scores for all known items will be returned.
 
@@ -137,15 +137,15 @@ class IBPR(Recommender):
             Relative scores that the user gives to the item or to all known items
 
         """
-        if item_id is None:
-            if self.train_set.is_unk_user(user_id):
-                raise ScoreException("Can't make score prediction for (user_id=%d)" % user_id)
+        if item_idx is None:
+            if self.train_set.is_unk_user(user_idx):
+                raise ScoreException("Can't make score prediction for (user_id=%d)" % user_idx)
 
-            known_item_scores = self.V.dot(self.U[user_id, :])
+            known_item_scores = self.V.dot(self.U[user_idx, :])
             return known_item_scores
         else:
-            if self.train_set.is_unk_user(user_id) or self.train_set.is_unk_item(item_id):
-                raise ScoreException("Can't make score prediction for (user_id=%d, item_id=%d)" % (user_id, item_id))
+            if self.train_set.is_unk_user(user_idx) or self.train_set.is_unk_item(item_idx):
+                raise ScoreException("Can't make score prediction for (user_id=%d, item_id=%d)" % (user_idx, item_idx))
 
-            user_pred = self.V[item_id, :].dot(self.U[user_id, :])
+            user_pred = self.V[item_idx, :].dot(self.U[user_idx, :])
             return user_pred

--- a/cornac/models/mcf/recom_mcf.py
+++ b/cornac/models/mcf/recom_mcf.py
@@ -151,15 +151,15 @@ class MCF(Recommender):
 
         return self
 
-    def score(self, user_id, item_id=None):
+    def score(self, user_idx, item_idx=None):
         """Predict the scores/ratings of a user for an item.
 
         Parameters
         ----------
-        user_id: int, required
+        user_idx: int, required
             The index of the user for whom to perform score prediction.
 
-        item_id: int, optional, default: None
+        item_idx: int, optional, default: None
             The index of the item for that to perform score prediction.
             If None, scores for all known items will be returned.
 
@@ -169,17 +169,17 @@ class MCF(Recommender):
             Relative scores that the user gives to the item or to all known items
 
         """
-        if item_id is None:
-            if self.train_set.is_unk_user(user_id):
-                raise ScoreException("Can't make score prediction for (user_id=%d)" % user_id)
+        if item_idx is None:
+            if self.train_set.is_unk_user(user_idx):
+                raise ScoreException("Can't make score prediction for (user_id=%d)" % user_idx)
 
-            known_item_scores = self.V.dot(self.U[user_id, :])
+            known_item_scores = self.V.dot(self.U[user_idx, :])
             return known_item_scores
         else:
-            if self.train_set.is_unk_user(user_id) or self.train_set.is_unk_item(item_id):
-                raise ScoreException("Can't make score prediction for (user_id=%d, item_id=%d)" % (user_id, item_id))
+            if self.train_set.is_unk_user(user_idx) or self.train_set.is_unk_item(item_idx):
+                raise ScoreException("Can't make score prediction for (user_id=%d, item_id=%d)" % (user_idx, item_idx))
 
-            user_pred = self.V[item_id, :].dot(self.U[user_id, :])
+            user_pred = self.V[item_idx, :].dot(self.U[user_idx, :])
 
             user_pred = sigmoid(user_pred)
             if self.train_set.min_rating == self.train_set.max_rating:

--- a/cornac/models/mcf/recom_mcf.py
+++ b/cornac/models/mcf/recom_mcf.py
@@ -91,10 +91,10 @@ class MCF(Recommender):
 
         Parameters
         ----------
-        train_set: :obj:`cornac.data.MultimodalTrainSet`, required
+        train_set: :obj:`cornac.data.Dataset`, required
             User-Item preference data as well as additional modalities.
 
-        val_set: :obj:`cornac.data.MultimodalTestSet`, optional, default: None
+        val_set: :obj:`cornac.data.Dataset`, optional, default: None
             User-Item preference data for model selection purposes (e.g., early stopping).
 
         Returns

--- a/cornac/models/mf/recom_mf.cpp
+++ b/cornac/models/mf/recom_mf.cpp
@@ -2528,12 +2528,11 @@ static const char __pyx_k_fit_sgd[] = "_fit_sgd";
 static const char __pyx_k_float32[] = "float32";
 static const char __pyx_k_fortran[] = "fortran";
 static const char __pyx_k_get_rng[] = "get_rng";
-static const char __pyx_k_item_id[] = "item_id";
+static const char __pyx_k_item_id[] = ", item_id=";
 static const char __pyx_k_memview[] = "memview";
 static const char __pyx_k_n_items[] = "n_items";
 static const char __pyx_k_n_users[] = "n_users";
 static const char __pyx_k_prepare[] = "__prepare__";
-static const char __pyx_k_user_id[] = "user_id";
 static const char __pyx_k_val_set[] = "val_set";
 static const char __pyx_k_verbose[] = "verbose";
 static const char __pyx_k_Ellipsis[] = "Ellipsis";
@@ -2542,6 +2541,7 @@ static const char __pyx_k_defaults[] = "defaults";
 static const char __pyx_k_fast_dot[] = "fast_dot";
 static const char __pyx_k_getstate[] = "__getstate__";
 static const char __pyx_k_i_biases[] = "i_biases";
+static const char __pyx_k_item_idx[] = "item_idx";
 static const char __pyx_k_itemsize[] = "itemsize";
 static const char __pyx_k_max_iter[] = "max_iter";
 static const char __pyx_k_progress[] = "progress";
@@ -2552,6 +2552,7 @@ static const char __pyx_k_u_biases[] = "u_biases";
 static const char __pyx_k_unk_item[] = "unk_item";
 static const char __pyx_k_unk_user[] = "unk_user";
 static const char __pyx_k_use_bias[] = "use_bias";
+static const char __pyx_k_user_idx[] = "user_idx";
 static const char __pyx_k_MF___init[] = "MF.__init__";
 static const char __pyx_k_TypeError[] = "TypeError";
 static const char __pyx_k_cpu_count[] = "cpu_count";
@@ -2559,7 +2560,6 @@ static const char __pyx_k_enumerate[] = "enumerate";
 static const char __pyx_k_exception[] = "exception";
 static const char __pyx_k_i_factors[] = "i_factors";
 static const char __pyx_k_int_float[] = "int|float";
-static const char __pyx_k_item_id_2[] = ", item_id=";
 static const char __pyx_k_last_loss[] = "last_loss";
 static const char __pyx_k_metaclass[] = "__metaclass__";
 static const char __pyx_k_num_items[] = "num_items";
@@ -2773,8 +2773,8 @@ static PyObject *__pyx_kp_s_int_float;
 static PyObject *__pyx_n_s_is_unk_item;
 static PyObject *__pyx_n_s_is_unk_user;
 static PyObject *__pyx_n_s_item;
-static PyObject *__pyx_n_s_item_id;
-static PyObject *__pyx_kp_u_item_id_2;
+static PyObject *__pyx_kp_u_item_id;
+static PyObject *__pyx_n_s_item_idx;
 static PyObject *__pyx_n_s_item_score;
 static PyObject *__pyx_n_s_itemsize;
 static PyObject *__pyx_kp_s_itemsize_0_for_cython_array;
@@ -2889,7 +2889,7 @@ static PyObject *__pyx_n_s_unpack;
 static PyObject *__pyx_n_s_update;
 static PyObject *__pyx_n_s_use_bias;
 static PyObject *__pyx_n_s_user;
-static PyObject *__pyx_n_s_user_id;
+static PyObject *__pyx_n_s_user_idx;
 static PyObject *__pyx_n_s_utils;
 static PyObject *__pyx_n_s_utils_init_utils;
 static PyObject *__pyx_n_s_val;
@@ -2905,7 +2905,7 @@ static PyObject *__pyx_pf_6cornac_6models_2mf_8recom_mf_2MF_12_fit_sgd(CYTHON_UN
 static PyObject *__pyx_pf_6cornac_6models_2mf_8recom_mf_2MF_14_fit_sgd(CYTHON_UNUSED PyObject *__pyx_self, PyObject *__pyx_v_self, __Pyx_memviewslice __pyx_v_rid, __Pyx_memviewslice __pyx_v_cid, __Pyx_memviewslice __pyx_v_val, __Pyx_memviewslice __pyx_v_U, __Pyx_memviewslice __pyx_v_V, __Pyx_memviewslice __pyx_v_Bu, __Pyx_memviewslice __pyx_v_Bi); /* proto */
 static PyObject *__pyx_pf_6cornac_6models_2mf_8recom_mf_2MF_16_fit_sgd(CYTHON_UNUSED PyObject *__pyx_self, PyObject *__pyx_v_self, __Pyx_memviewslice __pyx_v_rid, __Pyx_memviewslice __pyx_v_cid, __Pyx_memviewslice __pyx_v_val, __Pyx_memviewslice __pyx_v_U, __Pyx_memviewslice __pyx_v_V, __Pyx_memviewslice __pyx_v_Bu, __Pyx_memviewslice __pyx_v_Bi); /* proto */
 static PyObject *__pyx_pf_6cornac_6models_2mf_8recom_mf_2MF_18_fit_sgd(CYTHON_UNUSED PyObject *__pyx_self, PyObject *__pyx_v_self, __Pyx_memviewslice __pyx_v_rid, __Pyx_memviewslice __pyx_v_cid, __Pyx_memviewslice __pyx_v_val, __Pyx_memviewslice __pyx_v_U, __Pyx_memviewslice __pyx_v_V, __Pyx_memviewslice __pyx_v_Bu, __Pyx_memviewslice __pyx_v_Bi); /* proto */
-static PyObject *__pyx_pf_6cornac_6models_2mf_8recom_mf_2MF_6score(CYTHON_UNUSED PyObject *__pyx_self, PyObject *__pyx_v_self, PyObject *__pyx_v_user_id, PyObject *__pyx_v_item_id); /* proto */
+static PyObject *__pyx_pf_6cornac_6models_2mf_8recom_mf_2MF_6score(CYTHON_UNUSED PyObject *__pyx_self, PyObject *__pyx_v_self, PyObject *__pyx_v_user_idx, PyObject *__pyx_v_item_idx); /* proto */
 static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, Py_buffer *__pyx_v_info, int __pyx_v_flags); /* proto */
 static void __pyx_pf_5numpy_7ndarray_2__releasebuffer__(PyArrayObject *__pyx_v_self, Py_buffer *__pyx_v_info); /* proto */
 static int __pyx_array___pyx_pf_15View_dot_MemoryView_5array___cinit__(struct __pyx_array_obj *__pyx_v_self, PyObject *__pyx_v_shape, Py_ssize_t __pyx_v_itemsize, PyObject *__pyx_v_format, PyObject *__pyx_v_mode, int __pyx_v_allocate_buffer); /* proto */
@@ -3539,7 +3539,7 @@ static PyObject *__pyx_pf_6cornac_6models_2mf_8recom_mf_2MF___init__(CYTHON_UNUS
 
 /* Python wrapper */
 static PyObject *__pyx_pw_6cornac_6models_2mf_8recom_mf_2MF_3fit(PyObject *__pyx_self, PyObject *__pyx_args, PyObject *__pyx_kwds); /*proto*/
-static char __pyx_doc_6cornac_6models_2mf_8recom_mf_2MF_2fit[] = "Fit the model to observations.\n\n        Parameters\n        ----------\n        train_set: :obj:`cornac.data.MultimodalTrainSet`, required\n            User-Item preference data as well as additional modalities.\n\n        val_set: :obj:`cornac.data.MultimodalTestSet`, optional, default: None\n            User-Item preference data for model selection purposes (e.g., early stopping).\n\n        Returns\n        -------\n        self : object\n        ";
+static char __pyx_doc_6cornac_6models_2mf_8recom_mf_2MF_2fit[] = "Fit the model to observations.\n\n        Parameters\n        ----------\n        train_set: :obj:`cornac.data.Dataset`, required\n            User-Item preference data as well as additional modalities.\n\n        val_set: :obj:`cornac.data.Dataset`, optional, default: None\n            User-Item preference data for model selection purposes (e.g., early stopping).\n\n        Returns\n        -------\n        self : object\n        ";
 static PyMethodDef __pyx_mdef_6cornac_6models_2mf_8recom_mf_2MF_3fit = {"fit", (PyCFunction)(void*)(PyCFunctionWithKeywords)__pyx_pw_6cornac_6models_2mf_8recom_mf_2MF_3fit, METH_VARARGS|METH_KEYWORDS, __pyx_doc_6cornac_6models_2mf_8recom_mf_2MF_2fit};
 static PyObject *__pyx_pw_6cornac_6models_2mf_8recom_mf_2MF_3fit(PyObject *__pyx_self, PyObject *__pyx_args, PyObject *__pyx_kwds) {
   PyObject *__pyx_v_self = 0;
@@ -11218,24 +11218,24 @@ static PyObject *__pyx_pf_6cornac_6models_2mf_8recom_mf_2MF_18_fit_sgd(CYTHON_UN
 /* "cornac/models/mf/recom_mf.pyx":210
  * 
  * 
- *     def score(self, user_id, item_id=None):             # <<<<<<<<<<<<<<
+ *     def score(self, user_idx, item_idx=None):             # <<<<<<<<<<<<<<
  *         """Predict the scores/ratings of a user for an item.
  * 
  */
 
 /* Python wrapper */
 static PyObject *__pyx_pw_6cornac_6models_2mf_8recom_mf_2MF_7score(PyObject *__pyx_self, PyObject *__pyx_args, PyObject *__pyx_kwds); /*proto*/
-static char __pyx_doc_6cornac_6models_2mf_8recom_mf_2MF_6score[] = "Predict the scores/ratings of a user for an item.\n\n        Parameters\n        ----------\n        user_id: int, required\n            The index of the user for whom to perform score prediction.\n\n        item_id: int, optional, default: None\n            The index of the item for that to perform score prediction.\n            If None, scores for all known items will be returned.\n\n        Returns\n        -------\n        res : A scalar or a Numpy array\n            Relative scores that the user gives to the item or to all known items\n\n        ";
+static char __pyx_doc_6cornac_6models_2mf_8recom_mf_2MF_6score[] = "Predict the scores/ratings of a user for an item.\n\n        Parameters\n        ----------\n        user_idx: int, required\n            The index of the user for whom to perform score prediction.\n\n        item_idx: int, optional, default: None\n            The index of the item for that to perform score prediction.\n            If None, scores for all known items will be returned.\n\n        Returns\n        -------\n        res : A scalar or a Numpy array\n            Relative scores that the user gives to the item or to all known items\n\n        ";
 static PyMethodDef __pyx_mdef_6cornac_6models_2mf_8recom_mf_2MF_7score = {"score", (PyCFunction)(void*)(PyCFunctionWithKeywords)__pyx_pw_6cornac_6models_2mf_8recom_mf_2MF_7score, METH_VARARGS|METH_KEYWORDS, __pyx_doc_6cornac_6models_2mf_8recom_mf_2MF_6score};
 static PyObject *__pyx_pw_6cornac_6models_2mf_8recom_mf_2MF_7score(PyObject *__pyx_self, PyObject *__pyx_args, PyObject *__pyx_kwds) {
   PyObject *__pyx_v_self = 0;
-  PyObject *__pyx_v_user_id = 0;
-  PyObject *__pyx_v_item_id = 0;
+  PyObject *__pyx_v_user_idx = 0;
+  PyObject *__pyx_v_item_idx = 0;
   PyObject *__pyx_r = 0;
   __Pyx_RefNannyDeclarations
   __Pyx_RefNannySetupContext("score (wrapper)", 0);
   {
-    static PyObject **__pyx_pyargnames[] = {&__pyx_n_s_self,&__pyx_n_s_user_id,&__pyx_n_s_item_id,0};
+    static PyObject **__pyx_pyargnames[] = {&__pyx_n_s_self,&__pyx_n_s_user_idx,&__pyx_n_s_item_idx,0};
     PyObject* values[3] = {0,0,0};
     values[2] = ((PyObject *)((PyObject *)Py_None));
     if (unlikely(__pyx_kwds)) {
@@ -11258,14 +11258,14 @@ static PyObject *__pyx_pw_6cornac_6models_2mf_8recom_mf_2MF_7score(PyObject *__p
         else goto __pyx_L5_argtuple_error;
         CYTHON_FALLTHROUGH;
         case  1:
-        if (likely((values[1] = __Pyx_PyDict_GetItemStr(__pyx_kwds, __pyx_n_s_user_id)) != 0)) kw_args--;
+        if (likely((values[1] = __Pyx_PyDict_GetItemStr(__pyx_kwds, __pyx_n_s_user_idx)) != 0)) kw_args--;
         else {
           __Pyx_RaiseArgtupleInvalid("score", 0, 2, 3, 1); __PYX_ERR(0, 210, __pyx_L3_error)
         }
         CYTHON_FALLTHROUGH;
         case  2:
         if (kw_args > 0) {
-          PyObject* value = __Pyx_PyDict_GetItemStr(__pyx_kwds, __pyx_n_s_item_id);
+          PyObject* value = __Pyx_PyDict_GetItemStr(__pyx_kwds, __pyx_n_s_item_idx);
           if (value) { values[2] = value; kw_args--; }
         }
       }
@@ -11283,8 +11283,8 @@ static PyObject *__pyx_pw_6cornac_6models_2mf_8recom_mf_2MF_7score(PyObject *__p
       }
     }
     __pyx_v_self = values[0];
-    __pyx_v_user_id = values[1];
-    __pyx_v_item_id = values[2];
+    __pyx_v_user_idx = values[1];
+    __pyx_v_item_idx = values[2];
   }
   goto __pyx_L4_argument_unpacking_done;
   __pyx_L5_argtuple_error:;
@@ -11294,14 +11294,14 @@ static PyObject *__pyx_pw_6cornac_6models_2mf_8recom_mf_2MF_7score(PyObject *__p
   __Pyx_RefNannyFinishContext();
   return NULL;
   __pyx_L4_argument_unpacking_done:;
-  __pyx_r = __pyx_pf_6cornac_6models_2mf_8recom_mf_2MF_6score(__pyx_self, __pyx_v_self, __pyx_v_user_id, __pyx_v_item_id);
+  __pyx_r = __pyx_pf_6cornac_6models_2mf_8recom_mf_2MF_6score(__pyx_self, __pyx_v_self, __pyx_v_user_idx, __pyx_v_item_idx);
 
   /* function exit code */
   __Pyx_RefNannyFinishContext();
   return __pyx_r;
 }
 
-static PyObject *__pyx_pf_6cornac_6models_2mf_8recom_mf_2MF_6score(CYTHON_UNUSED PyObject *__pyx_self, PyObject *__pyx_v_self, PyObject *__pyx_v_user_id, PyObject *__pyx_v_item_id) {
+static PyObject *__pyx_pf_6cornac_6models_2mf_8recom_mf_2MF_6score(CYTHON_UNUSED PyObject *__pyx_self, PyObject *__pyx_v_self, PyObject *__pyx_v_user_idx, PyObject *__pyx_v_item_idx) {
   PyObject *__pyx_v_unk_user = NULL;
   PyObject *__pyx_v_known_item_scores = NULL;
   PyObject *__pyx_v_unk_item = NULL;
@@ -11325,9 +11325,9 @@ static PyObject *__pyx_pf_6cornac_6models_2mf_8recom_mf_2MF_6score(CYTHON_UNUSED
   /* "cornac/models/mf/recom_mf.pyx":228
  * 
  *         """
- *         unk_user = self.train_set.is_unk_user(user_id)             # <<<<<<<<<<<<<<
+ *         unk_user = self.train_set.is_unk_user(user_idx)             # <<<<<<<<<<<<<<
  * 
- *         if item_id is None:
+ *         if item_idx is None:
  */
   __pyx_t_2 = __Pyx_PyObject_GetAttrStr(__pyx_v_self, __pyx_n_s_train_set); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 228, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_2);
@@ -11344,7 +11344,7 @@ static PyObject *__pyx_pf_6cornac_6models_2mf_8recom_mf_2MF_6score(CYTHON_UNUSED
       __Pyx_DECREF_SET(__pyx_t_3, function);
     }
   }
-  __pyx_t_1 = (__pyx_t_2) ? __Pyx_PyObject_Call2Args(__pyx_t_3, __pyx_t_2, __pyx_v_user_id) : __Pyx_PyObject_CallOneArg(__pyx_t_3, __pyx_v_user_id);
+  __pyx_t_1 = (__pyx_t_2) ? __Pyx_PyObject_Call2Args(__pyx_t_3, __pyx_t_2, __pyx_v_user_idx) : __Pyx_PyObject_CallOneArg(__pyx_t_3, __pyx_v_user_idx);
   __Pyx_XDECREF(__pyx_t_2); __pyx_t_2 = 0;
   if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 228, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
@@ -11353,22 +11353,22 @@ static PyObject *__pyx_pf_6cornac_6models_2mf_8recom_mf_2MF_6score(CYTHON_UNUSED
   __pyx_t_1 = 0;
 
   /* "cornac/models/mf/recom_mf.pyx":230
- *         unk_user = self.train_set.is_unk_user(user_id)
+ *         unk_user = self.train_set.is_unk_user(user_idx)
  * 
- *         if item_id is None:             # <<<<<<<<<<<<<<
+ *         if item_idx is None:             # <<<<<<<<<<<<<<
  *             known_item_scores = np.add(self.i_biases, self.global_mean)
  *             if not unk_user:
  */
-  __pyx_t_4 = (__pyx_v_item_id == Py_None);
+  __pyx_t_4 = (__pyx_v_item_idx == Py_None);
   __pyx_t_5 = (__pyx_t_4 != 0);
   if (__pyx_t_5) {
 
     /* "cornac/models/mf/recom_mf.pyx":231
  * 
- *         if item_id is None:
+ *         if item_idx is None:
  *             known_item_scores = np.add(self.i_biases, self.global_mean)             # <<<<<<<<<<<<<<
  *             if not unk_user:
- *                 known_item_scores = np.add(known_item_scores, self.u_biases[user_id])
+ *                 known_item_scores = np.add(known_item_scores, self.u_biases[user_idx])
  */
     __Pyx_GetModuleGlobalName(__pyx_t_3, __pyx_n_s_np); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 231, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_3);
@@ -11432,11 +11432,11 @@ static PyObject *__pyx_pf_6cornac_6models_2mf_8recom_mf_2MF_6score(CYTHON_UNUSED
     __pyx_t_1 = 0;
 
     /* "cornac/models/mf/recom_mf.pyx":232
- *         if item_id is None:
+ *         if item_idx is None:
  *             known_item_scores = np.add(self.i_biases, self.global_mean)
  *             if not unk_user:             # <<<<<<<<<<<<<<
- *                 known_item_scores = np.add(known_item_scores, self.u_biases[user_id])
- *                 fast_dot(self.u_factors[user_id], self.i_factors, known_item_scores)
+ *                 known_item_scores = np.add(known_item_scores, self.u_biases[user_idx])
+ *                 fast_dot(self.u_factors[user_idx], self.i_factors, known_item_scores)
  */
     __pyx_t_5 = __Pyx_PyObject_IsTrue(__pyx_v_unk_user); if (unlikely(__pyx_t_5 < 0)) __PYX_ERR(0, 232, __pyx_L1_error)
     __pyx_t_4 = ((!__pyx_t_5) != 0);
@@ -11445,8 +11445,8 @@ static PyObject *__pyx_pf_6cornac_6models_2mf_8recom_mf_2MF_6score(CYTHON_UNUSED
       /* "cornac/models/mf/recom_mf.pyx":233
  *             known_item_scores = np.add(self.i_biases, self.global_mean)
  *             if not unk_user:
- *                 known_item_scores = np.add(known_item_scores, self.u_biases[user_id])             # <<<<<<<<<<<<<<
- *                 fast_dot(self.u_factors[user_id], self.i_factors, known_item_scores)
+ *                 known_item_scores = np.add(known_item_scores, self.u_biases[user_idx])             # <<<<<<<<<<<<<<
+ *                 fast_dot(self.u_factors[user_idx], self.i_factors, known_item_scores)
  *             return known_item_scores
  */
       __Pyx_GetModuleGlobalName(__pyx_t_2, __pyx_n_s_np); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 233, __pyx_L1_error)
@@ -11456,7 +11456,7 @@ static PyObject *__pyx_pf_6cornac_6models_2mf_8recom_mf_2MF_6score(CYTHON_UNUSED
       __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
       __pyx_t_2 = __Pyx_PyObject_GetAttrStr(__pyx_v_self, __pyx_n_s_u_biases); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 233, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_2);
-      __pyx_t_6 = __Pyx_PyObject_GetItem(__pyx_t_2, __pyx_v_user_id); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 233, __pyx_L1_error)
+      __pyx_t_6 = __Pyx_PyObject_GetItem(__pyx_t_2, __pyx_v_user_idx); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 233, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_6);
       __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
       __pyx_t_2 = NULL;
@@ -11511,8 +11511,8 @@ static PyObject *__pyx_pf_6cornac_6models_2mf_8recom_mf_2MF_6score(CYTHON_UNUSED
 
       /* "cornac/models/mf/recom_mf.pyx":234
  *             if not unk_user:
- *                 known_item_scores = np.add(known_item_scores, self.u_biases[user_id])
- *                 fast_dot(self.u_factors[user_id], self.i_factors, known_item_scores)             # <<<<<<<<<<<<<<
+ *                 known_item_scores = np.add(known_item_scores, self.u_biases[user_idx])
+ *                 fast_dot(self.u_factors[user_idx], self.i_factors, known_item_scores)             # <<<<<<<<<<<<<<
  *             return known_item_scores
  *         else:
  */
@@ -11520,7 +11520,7 @@ static PyObject *__pyx_pf_6cornac_6models_2mf_8recom_mf_2MF_6score(CYTHON_UNUSED
       __Pyx_GOTREF(__pyx_t_9);
       __pyx_t_3 = __Pyx_PyObject_GetAttrStr(__pyx_v_self, __pyx_n_s_u_factors); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 234, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_3);
-      __pyx_t_6 = __Pyx_PyObject_GetItem(__pyx_t_3, __pyx_v_user_id); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 234, __pyx_L1_error)
+      __pyx_t_6 = __Pyx_PyObject_GetItem(__pyx_t_3, __pyx_v_user_idx); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 234, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_6);
       __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
       __pyx_t_3 = __Pyx_PyObject_GetAttrStr(__pyx_v_self, __pyx_n_s_i_factors); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 234, __pyx_L1_error)
@@ -11580,20 +11580,20 @@ static PyObject *__pyx_pf_6cornac_6models_2mf_8recom_mf_2MF_6score(CYTHON_UNUSED
       __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
 
       /* "cornac/models/mf/recom_mf.pyx":232
- *         if item_id is None:
+ *         if item_idx is None:
  *             known_item_scores = np.add(self.i_biases, self.global_mean)
  *             if not unk_user:             # <<<<<<<<<<<<<<
- *                 known_item_scores = np.add(known_item_scores, self.u_biases[user_id])
- *                 fast_dot(self.u_factors[user_id], self.i_factors, known_item_scores)
+ *                 known_item_scores = np.add(known_item_scores, self.u_biases[user_idx])
+ *                 fast_dot(self.u_factors[user_idx], self.i_factors, known_item_scores)
  */
     }
 
     /* "cornac/models/mf/recom_mf.pyx":235
- *                 known_item_scores = np.add(known_item_scores, self.u_biases[user_id])
- *                 fast_dot(self.u_factors[user_id], self.i_factors, known_item_scores)
+ *                 known_item_scores = np.add(known_item_scores, self.u_biases[user_idx])
+ *                 fast_dot(self.u_factors[user_idx], self.i_factors, known_item_scores)
  *             return known_item_scores             # <<<<<<<<<<<<<<
  *         else:
- *             unk_item = self.train_set.is_unk_item(item_id)
+ *             unk_item = self.train_set.is_unk_item(item_idx)
  */
     __Pyx_XDECREF(__pyx_r);
     __Pyx_INCREF(__pyx_v_known_item_scores);
@@ -11601,9 +11601,9 @@ static PyObject *__pyx_pf_6cornac_6models_2mf_8recom_mf_2MF_6score(CYTHON_UNUSED
     goto __pyx_L0;
 
     /* "cornac/models/mf/recom_mf.pyx":230
- *         unk_user = self.train_set.is_unk_user(user_id)
+ *         unk_user = self.train_set.is_unk_user(user_idx)
  * 
- *         if item_id is None:             # <<<<<<<<<<<<<<
+ *         if item_idx is None:             # <<<<<<<<<<<<<<
  *             known_item_scores = np.add(self.i_biases, self.global_mean)
  *             if not unk_user:
  */
@@ -11612,7 +11612,7 @@ static PyObject *__pyx_pf_6cornac_6models_2mf_8recom_mf_2MF_6score(CYTHON_UNUSED
   /* "cornac/models/mf/recom_mf.pyx":237
  *             return known_item_scores
  *         else:
- *             unk_item = self.train_set.is_unk_item(item_id)             # <<<<<<<<<<<<<<
+ *             unk_item = self.train_set.is_unk_item(item_idx)             # <<<<<<<<<<<<<<
  *             if self.use_bias:
  *                 item_score = self.global_mean
  */
@@ -11632,7 +11632,7 @@ static PyObject *__pyx_pf_6cornac_6models_2mf_8recom_mf_2MF_6score(CYTHON_UNUSED
         __Pyx_DECREF_SET(__pyx_t_7, function);
       }
     }
-    __pyx_t_1 = (__pyx_t_9) ? __Pyx_PyObject_Call2Args(__pyx_t_7, __pyx_t_9, __pyx_v_item_id) : __Pyx_PyObject_CallOneArg(__pyx_t_7, __pyx_v_item_id);
+    __pyx_t_1 = (__pyx_t_9) ? __Pyx_PyObject_Call2Args(__pyx_t_7, __pyx_t_9, __pyx_v_item_idx) : __Pyx_PyObject_CallOneArg(__pyx_t_7, __pyx_v_item_idx);
     __Pyx_XDECREF(__pyx_t_9); __pyx_t_9 = 0;
     if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 237, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_1);
@@ -11642,7 +11642,7 @@ static PyObject *__pyx_pf_6cornac_6models_2mf_8recom_mf_2MF_6score(CYTHON_UNUSED
 
     /* "cornac/models/mf/recom_mf.pyx":238
  *         else:
- *             unk_item = self.train_set.is_unk_item(item_id)
+ *             unk_item = self.train_set.is_unk_item(item_idx)
  *             if self.use_bias:             # <<<<<<<<<<<<<<
  *                 item_score = self.global_mean
  *                 if not unk_user:
@@ -11654,11 +11654,11 @@ static PyObject *__pyx_pf_6cornac_6models_2mf_8recom_mf_2MF_6score(CYTHON_UNUSED
     if (__pyx_t_4) {
 
       /* "cornac/models/mf/recom_mf.pyx":239
- *             unk_item = self.train_set.is_unk_item(item_id)
+ *             unk_item = self.train_set.is_unk_item(item_idx)
  *             if self.use_bias:
  *                 item_score = self.global_mean             # <<<<<<<<<<<<<<
  *                 if not unk_user:
- *                     item_score += self.u_biases[user_id]
+ *                     item_score += self.u_biases[user_idx]
  */
       __pyx_t_1 = __Pyx_PyObject_GetAttrStr(__pyx_v_self, __pyx_n_s_global_mean); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 239, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_1);
@@ -11669,7 +11669,7 @@ static PyObject *__pyx_pf_6cornac_6models_2mf_8recom_mf_2MF_6score(CYTHON_UNUSED
  *             if self.use_bias:
  *                 item_score = self.global_mean
  *                 if not unk_user:             # <<<<<<<<<<<<<<
- *                     item_score += self.u_biases[user_id]
+ *                     item_score += self.u_biases[user_idx]
  *                 if not unk_item:
  */
       __pyx_t_4 = __Pyx_PyObject_IsTrue(__pyx_v_unk_user); if (unlikely(__pyx_t_4 < 0)) __PYX_ERR(0, 240, __pyx_L1_error)
@@ -11679,13 +11679,13 @@ static PyObject *__pyx_pf_6cornac_6models_2mf_8recom_mf_2MF_6score(CYTHON_UNUSED
         /* "cornac/models/mf/recom_mf.pyx":241
  *                 item_score = self.global_mean
  *                 if not unk_user:
- *                     item_score += self.u_biases[user_id]             # <<<<<<<<<<<<<<
+ *                     item_score += self.u_biases[user_idx]             # <<<<<<<<<<<<<<
  *                 if not unk_item:
- *                     item_score += self.i_biases[item_id]
+ *                     item_score += self.i_biases[item_idx]
  */
         __pyx_t_1 = __Pyx_PyObject_GetAttrStr(__pyx_v_self, __pyx_n_s_u_biases); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 241, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_1);
-        __pyx_t_7 = __Pyx_PyObject_GetItem(__pyx_t_1, __pyx_v_user_id); if (unlikely(!__pyx_t_7)) __PYX_ERR(0, 241, __pyx_L1_error)
+        __pyx_t_7 = __Pyx_PyObject_GetItem(__pyx_t_1, __pyx_v_user_idx); if (unlikely(!__pyx_t_7)) __PYX_ERR(0, 241, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_7);
         __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
         __pyx_t_1 = PyNumber_InPlaceAdd(__pyx_v_item_score, __pyx_t_7); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 241, __pyx_L1_error)
@@ -11698,16 +11698,16 @@ static PyObject *__pyx_pf_6cornac_6models_2mf_8recom_mf_2MF_6score(CYTHON_UNUSED
  *             if self.use_bias:
  *                 item_score = self.global_mean
  *                 if not unk_user:             # <<<<<<<<<<<<<<
- *                     item_score += self.u_biases[user_id]
+ *                     item_score += self.u_biases[user_idx]
  *                 if not unk_item:
  */
       }
 
       /* "cornac/models/mf/recom_mf.pyx":242
  *                 if not unk_user:
- *                     item_score += self.u_biases[user_id]
+ *                     item_score += self.u_biases[user_idx]
  *                 if not unk_item:             # <<<<<<<<<<<<<<
- *                     item_score += self.i_biases[item_id]
+ *                     item_score += self.i_biases[item_idx]
  *                 if not unk_user and not unk_item:
  */
       __pyx_t_5 = __Pyx_PyObject_IsTrue(__pyx_v_unk_item); if (unlikely(__pyx_t_5 < 0)) __PYX_ERR(0, 242, __pyx_L1_error)
@@ -11715,15 +11715,15 @@ static PyObject *__pyx_pf_6cornac_6models_2mf_8recom_mf_2MF_6score(CYTHON_UNUSED
       if (__pyx_t_4) {
 
         /* "cornac/models/mf/recom_mf.pyx":243
- *                     item_score += self.u_biases[user_id]
+ *                     item_score += self.u_biases[user_idx]
  *                 if not unk_item:
- *                     item_score += self.i_biases[item_id]             # <<<<<<<<<<<<<<
+ *                     item_score += self.i_biases[item_idx]             # <<<<<<<<<<<<<<
  *                 if not unk_user and not unk_item:
- *                     item_score += np.dot(self.u_factors[user_id], self.i_factors[item_id])
+ *                     item_score += np.dot(self.u_factors[user_idx], self.i_factors[item_idx])
  */
         __pyx_t_1 = __Pyx_PyObject_GetAttrStr(__pyx_v_self, __pyx_n_s_i_biases); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 243, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_1);
-        __pyx_t_7 = __Pyx_PyObject_GetItem(__pyx_t_1, __pyx_v_item_id); if (unlikely(!__pyx_t_7)) __PYX_ERR(0, 243, __pyx_L1_error)
+        __pyx_t_7 = __Pyx_PyObject_GetItem(__pyx_t_1, __pyx_v_item_idx); if (unlikely(!__pyx_t_7)) __PYX_ERR(0, 243, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_7);
         __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
         __pyx_t_1 = PyNumber_InPlaceAdd(__pyx_v_item_score, __pyx_t_7); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 243, __pyx_L1_error)
@@ -11734,18 +11734,18 @@ static PyObject *__pyx_pf_6cornac_6models_2mf_8recom_mf_2MF_6score(CYTHON_UNUSED
 
         /* "cornac/models/mf/recom_mf.pyx":242
  *                 if not unk_user:
- *                     item_score += self.u_biases[user_id]
+ *                     item_score += self.u_biases[user_idx]
  *                 if not unk_item:             # <<<<<<<<<<<<<<
- *                     item_score += self.i_biases[item_id]
+ *                     item_score += self.i_biases[item_idx]
  *                 if not unk_user and not unk_item:
  */
       }
 
       /* "cornac/models/mf/recom_mf.pyx":244
  *                 if not unk_item:
- *                     item_score += self.i_biases[item_id]
+ *                     item_score += self.i_biases[item_idx]
  *                 if not unk_user and not unk_item:             # <<<<<<<<<<<<<<
- *                     item_score += np.dot(self.u_factors[user_id], self.i_factors[item_id])
+ *                     item_score += np.dot(self.u_factors[user_idx], self.i_factors[item_idx])
  *             else:
  */
       __pyx_t_5 = __Pyx_PyObject_IsTrue(__pyx_v_unk_user); if (unlikely(__pyx_t_5 < 0)) __PYX_ERR(0, 244, __pyx_L1_error)
@@ -11762,9 +11762,9 @@ static PyObject *__pyx_pf_6cornac_6models_2mf_8recom_mf_2MF_6score(CYTHON_UNUSED
       if (__pyx_t_4) {
 
         /* "cornac/models/mf/recom_mf.pyx":245
- *                     item_score += self.i_biases[item_id]
+ *                     item_score += self.i_biases[item_idx]
  *                 if not unk_user and not unk_item:
- *                     item_score += np.dot(self.u_factors[user_id], self.i_factors[item_id])             # <<<<<<<<<<<<<<
+ *                     item_score += np.dot(self.u_factors[user_idx], self.i_factors[item_idx])             # <<<<<<<<<<<<<<
  *             else:
  *                 if unk_user or unk_item:
  */
@@ -11775,12 +11775,12 @@ static PyObject *__pyx_pf_6cornac_6models_2mf_8recom_mf_2MF_6score(CYTHON_UNUSED
         __Pyx_DECREF(__pyx_t_7); __pyx_t_7 = 0;
         __pyx_t_7 = __Pyx_PyObject_GetAttrStr(__pyx_v_self, __pyx_n_s_u_factors); if (unlikely(!__pyx_t_7)) __PYX_ERR(0, 245, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_7);
-        __pyx_t_3 = __Pyx_PyObject_GetItem(__pyx_t_7, __pyx_v_user_id); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 245, __pyx_L1_error)
+        __pyx_t_3 = __Pyx_PyObject_GetItem(__pyx_t_7, __pyx_v_user_idx); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 245, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_3);
         __Pyx_DECREF(__pyx_t_7); __pyx_t_7 = 0;
         __pyx_t_7 = __Pyx_PyObject_GetAttrStr(__pyx_v_self, __pyx_n_s_i_factors); if (unlikely(!__pyx_t_7)) __PYX_ERR(0, 245, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_7);
-        __pyx_t_6 = __Pyx_PyObject_GetItem(__pyx_t_7, __pyx_v_item_id); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 245, __pyx_L1_error)
+        __pyx_t_6 = __Pyx_PyObject_GetItem(__pyx_t_7, __pyx_v_item_idx); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 245, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_6);
         __Pyx_DECREF(__pyx_t_7); __pyx_t_7 = 0;
         __pyx_t_7 = NULL;
@@ -11840,16 +11840,16 @@ static PyObject *__pyx_pf_6cornac_6models_2mf_8recom_mf_2MF_6score(CYTHON_UNUSED
 
         /* "cornac/models/mf/recom_mf.pyx":244
  *                 if not unk_item:
- *                     item_score += self.i_biases[item_id]
+ *                     item_score += self.i_biases[item_idx]
  *                 if not unk_user and not unk_item:             # <<<<<<<<<<<<<<
- *                     item_score += np.dot(self.u_factors[user_id], self.i_factors[item_id])
+ *                     item_score += np.dot(self.u_factors[user_idx], self.i_factors[item_idx])
  *             else:
  */
       }
 
       /* "cornac/models/mf/recom_mf.pyx":238
  *         else:
- *             unk_item = self.train_set.is_unk_item(item_id)
+ *             unk_item = self.train_set.is_unk_item(item_idx)
  *             if self.use_bias:             # <<<<<<<<<<<<<<
  *                 item_score = self.global_mean
  *                 if not unk_user:
@@ -11858,11 +11858,11 @@ static PyObject *__pyx_pf_6cornac_6models_2mf_8recom_mf_2MF_6score(CYTHON_UNUSED
     }
 
     /* "cornac/models/mf/recom_mf.pyx":247
- *                     item_score += np.dot(self.u_factors[user_id], self.i_factors[item_id])
+ *                     item_score += np.dot(self.u_factors[user_idx], self.i_factors[item_idx])
  *             else:
  *                 if unk_user or unk_item:             # <<<<<<<<<<<<<<
- *                     raise ScoreException("Can't make score prediction for (user_id=%d, item_id=%d)" % (user_id, item_id))
- *                 item_score = np.dot(self.u_factors[user_id], self.i_factors[item_id])
+ *                     raise ScoreException("Can't make score prediction for (user_id=%d, item_id=%d)" % (user_idx, item_idx))
+ *                 item_score = np.dot(self.u_factors[user_idx], self.i_factors[item_idx])
  */
     /*else*/ {
       __pyx_t_5 = __Pyx_PyObject_IsTrue(__pyx_v_unk_user); if (unlikely(__pyx_t_5 < 0)) __PYX_ERR(0, 247, __pyx_L1_error)
@@ -11879,8 +11879,8 @@ static PyObject *__pyx_pf_6cornac_6models_2mf_8recom_mf_2MF_6score(CYTHON_UNUSED
         /* "cornac/models/mf/recom_mf.pyx":248
  *             else:
  *                 if unk_user or unk_item:
- *                     raise ScoreException("Can't make score prediction for (user_id=%d, item_id=%d)" % (user_id, item_id))             # <<<<<<<<<<<<<<
- *                 item_score = np.dot(self.u_factors[user_id], self.i_factors[item_id])
+ *                     raise ScoreException("Can't make score prediction for (user_id=%d, item_id=%d)" % (user_idx, item_idx))             # <<<<<<<<<<<<<<
+ *                 item_score = np.dot(self.u_factors[user_idx], self.i_factors[item_idx])
  *             return item_score
  */
         __Pyx_GetModuleGlobalName(__pyx_t_1, __pyx_n_s_ScoreException); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 248, __pyx_L1_error)
@@ -11893,18 +11893,18 @@ static PyObject *__pyx_pf_6cornac_6models_2mf_8recom_mf_2MF_6score(CYTHON_UNUSED
         __pyx_t_11 += 41;
         __Pyx_GIVEREF(__pyx_kp_u_Can_t_make_score_prediction_for);
         PyTuple_SET_ITEM(__pyx_t_2, 0, __pyx_kp_u_Can_t_make_score_prediction_for);
-        __pyx_t_6 = __Pyx_PyObject_Format(__pyx_v_user_id, __pyx_n_u_d); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 248, __pyx_L1_error)
+        __pyx_t_6 = __Pyx_PyObject_Format(__pyx_v_user_idx, __pyx_n_u_d); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 248, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_6);
         __pyx_t_12 = (__Pyx_PyUnicode_MAX_CHAR_VALUE(__pyx_t_6) > __pyx_t_12) ? __Pyx_PyUnicode_MAX_CHAR_VALUE(__pyx_t_6) : __pyx_t_12;
         __pyx_t_11 += __Pyx_PyUnicode_GET_LENGTH(__pyx_t_6);
         __Pyx_GIVEREF(__pyx_t_6);
         PyTuple_SET_ITEM(__pyx_t_2, 1, __pyx_t_6);
         __pyx_t_6 = 0;
-        __Pyx_INCREF(__pyx_kp_u_item_id_2);
+        __Pyx_INCREF(__pyx_kp_u_item_id);
         __pyx_t_11 += 10;
-        __Pyx_GIVEREF(__pyx_kp_u_item_id_2);
-        PyTuple_SET_ITEM(__pyx_t_2, 2, __pyx_kp_u_item_id_2);
-        __pyx_t_6 = __Pyx_PyObject_Format(__pyx_v_item_id, __pyx_n_u_d); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 248, __pyx_L1_error)
+        __Pyx_GIVEREF(__pyx_kp_u_item_id);
+        PyTuple_SET_ITEM(__pyx_t_2, 2, __pyx_kp_u_item_id);
+        __pyx_t_6 = __Pyx_PyObject_Format(__pyx_v_item_idx, __pyx_n_u_d); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 248, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_6);
         __pyx_t_12 = (__Pyx_PyUnicode_MAX_CHAR_VALUE(__pyx_t_6) > __pyx_t_12) ? __Pyx_PyUnicode_MAX_CHAR_VALUE(__pyx_t_6) : __pyx_t_12;
         __pyx_t_11 += __Pyx_PyUnicode_GET_LENGTH(__pyx_t_6);
@@ -11939,18 +11939,18 @@ static PyObject *__pyx_pf_6cornac_6models_2mf_8recom_mf_2MF_6score(CYTHON_UNUSED
         __PYX_ERR(0, 248, __pyx_L1_error)
 
         /* "cornac/models/mf/recom_mf.pyx":247
- *                     item_score += np.dot(self.u_factors[user_id], self.i_factors[item_id])
+ *                     item_score += np.dot(self.u_factors[user_idx], self.i_factors[item_idx])
  *             else:
  *                 if unk_user or unk_item:             # <<<<<<<<<<<<<<
- *                     raise ScoreException("Can't make score prediction for (user_id=%d, item_id=%d)" % (user_id, item_id))
- *                 item_score = np.dot(self.u_factors[user_id], self.i_factors[item_id])
+ *                     raise ScoreException("Can't make score prediction for (user_id=%d, item_id=%d)" % (user_idx, item_idx))
+ *                 item_score = np.dot(self.u_factors[user_idx], self.i_factors[item_idx])
  */
       }
 
       /* "cornac/models/mf/recom_mf.pyx":249
  *                 if unk_user or unk_item:
- *                     raise ScoreException("Can't make score prediction for (user_id=%d, item_id=%d)" % (user_id, item_id))
- *                 item_score = np.dot(self.u_factors[user_id], self.i_factors[item_id])             # <<<<<<<<<<<<<<
+ *                     raise ScoreException("Can't make score prediction for (user_id=%d, item_id=%d)" % (user_idx, item_idx))
+ *                 item_score = np.dot(self.u_factors[user_idx], self.i_factors[item_idx])             # <<<<<<<<<<<<<<
  *             return item_score
  */
       __Pyx_GetModuleGlobalName(__pyx_t_1, __pyx_n_s_np); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 249, __pyx_L1_error)
@@ -11960,12 +11960,12 @@ static PyObject *__pyx_pf_6cornac_6models_2mf_8recom_mf_2MF_6score(CYTHON_UNUSED
       __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
       __pyx_t_1 = __Pyx_PyObject_GetAttrStr(__pyx_v_self, __pyx_n_s_u_factors); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 249, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_1);
-      __pyx_t_2 = __Pyx_PyObject_GetItem(__pyx_t_1, __pyx_v_user_id); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 249, __pyx_L1_error)
+      __pyx_t_2 = __Pyx_PyObject_GetItem(__pyx_t_1, __pyx_v_user_idx); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 249, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_2);
       __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
       __pyx_t_1 = __Pyx_PyObject_GetAttrStr(__pyx_v_self, __pyx_n_s_i_factors); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 249, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_1);
-      __pyx_t_3 = __Pyx_PyObject_GetItem(__pyx_t_1, __pyx_v_item_id); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 249, __pyx_L1_error)
+      __pyx_t_3 = __Pyx_PyObject_GetItem(__pyx_t_1, __pyx_v_item_idx); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 249, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_3);
       __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
       __pyx_t_1 = NULL;
@@ -12023,8 +12023,8 @@ static PyObject *__pyx_pf_6cornac_6models_2mf_8recom_mf_2MF_6score(CYTHON_UNUSED
     __pyx_L5:;
 
     /* "cornac/models/mf/recom_mf.pyx":250
- *                     raise ScoreException("Can't make score prediction for (user_id=%d, item_id=%d)" % (user_id, item_id))
- *                 item_score = np.dot(self.u_factors[user_id], self.i_factors[item_id])
+ *                     raise ScoreException("Can't make score prediction for (user_id=%d, item_id=%d)" % (user_idx, item_idx))
+ *                 item_score = np.dot(self.u_factors[user_idx], self.i_factors[item_idx])
  *             return item_score             # <<<<<<<<<<<<<<
  */
     __Pyx_XDECREF(__pyx_r);
@@ -12036,7 +12036,7 @@ static PyObject *__pyx_pf_6cornac_6models_2mf_8recom_mf_2MF_6score(CYTHON_UNUSED
   /* "cornac/models/mf/recom_mf.pyx":210
  * 
  * 
- *     def score(self, user_id, item_id=None):             # <<<<<<<<<<<<<<
+ *     def score(self, user_idx, item_idx=None):             # <<<<<<<<<<<<<<
  *         """Predict the scores/ratings of a user for an item.
  * 
  */
@@ -28086,8 +28086,8 @@ static __Pyx_StringTabEntry __pyx_string_tab[] = {
   {&__pyx_n_s_is_unk_item, __pyx_k_is_unk_item, sizeof(__pyx_k_is_unk_item), 0, 0, 1, 1},
   {&__pyx_n_s_is_unk_user, __pyx_k_is_unk_user, sizeof(__pyx_k_is_unk_user), 0, 0, 1, 1},
   {&__pyx_n_s_item, __pyx_k_item, sizeof(__pyx_k_item), 0, 0, 1, 1},
-  {&__pyx_n_s_item_id, __pyx_k_item_id, sizeof(__pyx_k_item_id), 0, 0, 1, 1},
-  {&__pyx_kp_u_item_id_2, __pyx_k_item_id_2, sizeof(__pyx_k_item_id_2), 0, 1, 0, 0},
+  {&__pyx_kp_u_item_id, __pyx_k_item_id, sizeof(__pyx_k_item_id), 0, 1, 0, 0},
+  {&__pyx_n_s_item_idx, __pyx_k_item_idx, sizeof(__pyx_k_item_idx), 0, 0, 1, 1},
   {&__pyx_n_s_item_score, __pyx_k_item_score, sizeof(__pyx_k_item_score), 0, 0, 1, 1},
   {&__pyx_n_s_itemsize, __pyx_k_itemsize, sizeof(__pyx_k_itemsize), 0, 0, 1, 1},
   {&__pyx_kp_s_itemsize_0_for_cython_array, __pyx_k_itemsize_0_for_cython_array, sizeof(__pyx_k_itemsize_0_for_cython_array), 0, 0, 1, 0},
@@ -28202,7 +28202,7 @@ static __Pyx_StringTabEntry __pyx_string_tab[] = {
   {&__pyx_n_s_update, __pyx_k_update, sizeof(__pyx_k_update), 0, 0, 1, 1},
   {&__pyx_n_s_use_bias, __pyx_k_use_bias, sizeof(__pyx_k_use_bias), 0, 0, 1, 1},
   {&__pyx_n_s_user, __pyx_k_user, sizeof(__pyx_k_user), 0, 0, 1, 1},
-  {&__pyx_n_s_user_id, __pyx_k_user_id, sizeof(__pyx_k_user_id), 0, 0, 1, 1},
+  {&__pyx_n_s_user_idx, __pyx_k_user_idx, sizeof(__pyx_k_user_idx), 0, 0, 1, 1},
   {&__pyx_n_s_utils, __pyx_k_utils, sizeof(__pyx_k_utils), 0, 0, 1, 1},
   {&__pyx_n_s_utils_init_utils, __pyx_k_utils_init_utils, sizeof(__pyx_k_utils_init_utils), 0, 0, 1, 1},
   {&__pyx_n_s_val, __pyx_k_val, sizeof(__pyx_k_val), 0, 0, 1, 1},
@@ -28572,11 +28572,11 @@ static CYTHON_SMALL_CODE int __Pyx_InitCachedConstants(void) {
   /* "cornac/models/mf/recom_mf.pyx":210
  * 
  * 
- *     def score(self, user_id, item_id=None):             # <<<<<<<<<<<<<<
+ *     def score(self, user_idx, item_idx=None):             # <<<<<<<<<<<<<<
  *         """Predict the scores/ratings of a user for an item.
  * 
  */
-  __pyx_tuple__40 = PyTuple_Pack(7, __pyx_n_s_self, __pyx_n_s_user_id, __pyx_n_s_item_id, __pyx_n_s_unk_user, __pyx_n_s_known_item_scores, __pyx_n_s_unk_item, __pyx_n_s_item_score); if (unlikely(!__pyx_tuple__40)) __PYX_ERR(0, 210, __pyx_L1_error)
+  __pyx_tuple__40 = PyTuple_Pack(7, __pyx_n_s_self, __pyx_n_s_user_idx, __pyx_n_s_item_idx, __pyx_n_s_unk_user, __pyx_n_s_known_item_scores, __pyx_n_s_unk_item, __pyx_n_s_item_score); if (unlikely(!__pyx_tuple__40)) __PYX_ERR(0, 210, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_tuple__40);
   __Pyx_GIVEREF(__pyx_tuple__40);
   __pyx_codeobj__41 = (PyObject*)__Pyx_PyCode_New(3, 0, 7, 0, CO_OPTIMIZED|CO_NEWLOCALS, __pyx_empty_bytes, __pyx_empty_tuple, __pyx_empty_tuple, __pyx_tuple__40, __pyx_empty_tuple, __pyx_empty_tuple, __pyx_kp_s_cornac_models_mf_recom_mf_pyx, __pyx_n_s_score, 210, __pyx_empty_bytes); if (unlikely(!__pyx_codeobj__41)) __PYX_ERR(0, 210, __pyx_L1_error)
@@ -29203,7 +29203,7 @@ if (!__Pyx_RefNanny) {
   /* "cornac/models/mf/recom_mf.pyx":210
  * 
  * 
- *     def score(self, user_id, item_id=None):             # <<<<<<<<<<<<<<
+ *     def score(self, user_idx, item_idx=None):             # <<<<<<<<<<<<<<
  *         """Predict the scores/ratings of a user for an item.
  * 
  */

--- a/cornac/models/mf/recom_mf.pyx
+++ b/cornac/models/mf/recom_mf.pyx
@@ -207,15 +207,15 @@ class MF(Recommender):
             print('Optimization finished!')
 
 
-    def score(self, user_id, item_id=None):
+    def score(self, user_idx, item_idx=None):
         """Predict the scores/ratings of a user for an item.
 
         Parameters
         ----------
-        user_id: int, required
+        user_idx: int, required
             The index of the user for whom to perform score prediction.
 
-        item_id: int, optional, default: None
+        item_idx: int, optional, default: None
             The index of the item for that to perform score prediction.
             If None, scores for all known items will be returned.
 
@@ -225,26 +225,26 @@ class MF(Recommender):
             Relative scores that the user gives to the item or to all known items
 
         """
-        unk_user = self.train_set.is_unk_user(user_id)
+        unk_user = self.train_set.is_unk_user(user_idx)
 
-        if item_id is None:
+        if item_idx is None:
             known_item_scores = np.add(self.i_biases, self.global_mean)
             if not unk_user:
-                known_item_scores = np.add(known_item_scores, self.u_biases[user_id])
-                fast_dot(self.u_factors[user_id], self.i_factors, known_item_scores)
+                known_item_scores = np.add(known_item_scores, self.u_biases[user_idx])
+                fast_dot(self.u_factors[user_idx], self.i_factors, known_item_scores)
             return known_item_scores
         else:
-            unk_item = self.train_set.is_unk_item(item_id)
+            unk_item = self.train_set.is_unk_item(item_idx)
             if self.use_bias:
                 item_score = self.global_mean
                 if not unk_user:
-                    item_score += self.u_biases[user_id]
+                    item_score += self.u_biases[user_idx]
                 if not unk_item:
-                    item_score += self.i_biases[item_id]
+                    item_score += self.i_biases[item_idx]
                 if not unk_user and not unk_item:
-                    item_score += np.dot(self.u_factors[user_id], self.i_factors[item_id])
+                    item_score += np.dot(self.u_factors[user_idx], self.i_factors[item_idx])
             else:
                 if unk_user or unk_item:
-                    raise ScoreException("Can't make score prediction for (user_id=%d, item_id=%d)" % (user_id, item_id))
-                item_score = np.dot(self.u_factors[user_id], self.i_factors[item_id])
+                    raise ScoreException("Can't make score prediction for (user_id=%d, item_id=%d)" % (user_idx, item_idx))
+                item_score = np.dot(self.u_factors[user_idx], self.i_factors[item_idx])
             return item_score

--- a/cornac/models/mf/recom_mf.pyx
+++ b/cornac/models/mf/recom_mf.pyx
@@ -102,10 +102,10 @@ class MF(Recommender):
 
         Parameters
         ----------
-        train_set: :obj:`cornac.data.MultimodalTrainSet`, required
+        train_set: :obj:`cornac.data.Dataset`, required
             User-Item preference data as well as additional modalities.
 
-        val_set: :obj:`cornac.data.MultimodalTestSet`, optional, default: None
+        val_set: :obj:`cornac.data.Dataset`, optional, default: None
             User-Item preference data for model selection purposes (e.g., early stopping).
 
         Returns

--- a/cornac/models/ncf/recom_gmf.py
+++ b/cornac/models/ncf/recom_gmf.py
@@ -154,15 +154,15 @@ class GMF(Recommender):
                 if i % 10 == 0:
                     loop.set_postfix(loss=(sum_loss / count))
 
-    def score(self, user_id, item_id=None):
+    def score(self, user_idx, item_idx=None):
         """Predict the scores/ratings of a user for an item.
 
         Parameters
         ----------
-        user_id: int, required
+        user_idx: int, required
             The index of the user for whom to perform score prediction.
 
-        item_id: int, optional, default: None
+        item_idx: int, optional, default: None
             The index of the item for that to perform score prediction.
             If None, scores for all known items will be returned.
 
@@ -171,19 +171,19 @@ class GMF(Recommender):
         res : A scalar or a Numpy array
             Relative scores that the user gives to the item or to all known items
         """
-        if item_id is None:
-            if self.train_set.is_unk_user(user_id):
-                raise ScoreException("Can't make score prediction for (user_id=%d)" % user_id)
+        if item_idx is None:
+            if self.train_set.is_unk_user(user_idx):
+                raise ScoreException("Can't make score prediction for (user_id=%d)" % user_idx)
 
             known_item_scores = self.sess.run(self.prediction, feed_dict={
-                self.user_id: [user_id], self.item_id: np.arange(self.train_set.num_items)
+                self.user_id: [user_idx], self.item_id: np.arange(self.train_set.num_items)
             })
             return known_item_scores.ravel()
         else:
-            if self.train_set.is_unk_user(user_id) or self.train_set.is_unk_item(item_id):
-                raise ScoreException("Can't make score prediction for (user_id=%d, item_id=%d)" % (user_id, item_id))
+            if self.train_set.is_unk_user(user_idx) or self.train_set.is_unk_item(item_idx):
+                raise ScoreException("Can't make score prediction for (user_id=%d, item_id=%d)" % (user_idx, item_idx))
 
             user_pred = self.sess.run(self.prediction, feed_dict={
-                self.user_id: [user_id], self.item_id: [item_id]
+                self.user_id: [user_idx], self.item_id: [item_idx]
             })
             return user_pred.ravel()

--- a/cornac/models/ncf/recom_gmf.py
+++ b/cornac/models/ncf/recom_gmf.py
@@ -83,10 +83,10 @@ class GMF(Recommender):
 
         Parameters
         ----------
-        train_set: :obj:`cornac.data.MultimodalTrainSet`, required
+        train_set: :obj:`cornac.data.Dataset`, required
             User-Item preference data as well as additional modalities.
 
-        val_set: :obj:`cornac.data.MultimodalTestSet`, optional, default: None
+        val_set: :obj:`cornac.data.Dataset`, optional, default: None
             User-Item preference data for model selection purposes (e.g., early stopping).
 
         Returns

--- a/cornac/models/ncf/recom_mlp.py
+++ b/cornac/models/ncf/recom_mlp.py
@@ -161,15 +161,15 @@ class MLP(Recommender):
                 if i % 10 == 0:
                     loop.set_postfix(loss=(sum_loss / count))
 
-    def score(self, user_id, item_id=None):
+    def score(self, user_idx, item_idx=None):
         """Predict the scores/ratings of a user for an item.
 
         Parameters
         ----------
-        user_id: int, required
+        user_idx: int, required
             The index of the user for whom to perform score prediction.
 
-        item_id: int, optional, default: None
+        item_idx: int, optional, default: None
             The index of the item for that to perform score prediction.
             If None, scores for all known items will be returned.
 
@@ -178,20 +178,20 @@ class MLP(Recommender):
         res : A scalar or a Numpy array
             Relative scores that the user gives to the item or to all known items
         """
-        if item_id is None:
-            if self.train_set.is_unk_user(user_id):
-                raise ScoreException("Can't make score prediction for (user_id=%d)" % user_id)
+        if item_idx is None:
+            if self.train_set.is_unk_user(user_idx):
+                raise ScoreException("Can't make score prediction for (user_id=%d)" % user_idx)
 
             known_item_scores = self.sess.run(self.prediction, feed_dict={
-                self.user_id: np.ones(self.train_set.num_items) * user_id,
+                self.user_id: np.ones(self.train_set.num_items) * user_idx,
                 self.item_id: np.arange(self.train_set.num_items)
             })
             return known_item_scores.ravel()
         else:
-            if self.train_set.is_unk_user(user_id) or self.train_set.is_unk_item(item_id):
-                raise ScoreException("Can't make score prediction for (user_id=%d, item_id=%d)" % (user_id, item_id))
+            if self.train_set.is_unk_user(user_idx) or self.train_set.is_unk_item(item_idx):
+                raise ScoreException("Can't make score prediction for (user_id=%d, item_id=%d)" % (user_idx, item_idx))
 
             user_pred = self.sess.run(self.prediction, feed_dict={
-                self.user_id: [user_id], self.item_id: [item_id]
+                self.user_id: [user_idx], self.item_id: [item_idx]
             })
             return user_pred.ravel()

--- a/cornac/models/ncf/recom_mlp.py
+++ b/cornac/models/ncf/recom_mlp.py
@@ -91,10 +91,10 @@ class MLP(Recommender):
 
         Parameters
         ----------
-        train_set: :obj:`cornac.data.MultimodalTrainSet`, required
+        train_set: :obj:`cornac.data.Dataset`, required
             User-Item preference data as well as additional modalities.
 
-        val_set: :obj:`cornac.data.MultimodalTestSet`, optional, default: None
+        val_set: :obj:`cornac.data.Dataset`, optional, default: None
             User-Item preference data for model selection purposes (e.g., early stopping).
 
         Returns

--- a/cornac/models/ncf/recom_neumf.py
+++ b/cornac/models/ncf/recom_neumf.py
@@ -217,15 +217,15 @@ class NeuMF(Recommender):
                 if i % 10 == 0:
                     loop.set_postfix(loss=(sum_loss / count))
 
-    def score(self, user_id, item_id=None):
+    def score(self, user_idx, item_idx=None):
         """Predict the scores/ratings of a user for an item.
 
         Parameters
         ----------
-        user_id: int, required
+        user_idx: int, required
             The index of the user for whom to perform score prediction.
 
-        item_id: int, optional, default: None
+        item_idx: int, optional, default: None
             The index of the item for that to perform score prediction.
             If None, scores for all known items will be returned.
 
@@ -234,21 +234,21 @@ class NeuMF(Recommender):
         res : A scalar or a Numpy array
             Relative scores that the user gives to the item or to all known items
         """
-        if item_id is None:
-            if self.train_set.is_unk_user(user_id):
-                raise ScoreException("Can't make score prediction for (user_id=%d)" % user_id)
+        if item_idx is None:
+            if self.train_set.is_unk_user(user_idx):
+                raise ScoreException("Can't make score prediction for (user_id=%d)" % user_idx)
 
             known_item_scores = self.sess.run(self.prediction, feed_dict={
-                self.gmf_user_id: [user_id],
-                self.mlp_user_id: np.ones(self.train_set.num_items) * user_id,
+                self.gmf_user_id: [user_idx],
+                self.mlp_user_id: np.ones(self.train_set.num_items) * user_idx,
                 self.item_id: np.arange(self.train_set.num_items)
             })
             return known_item_scores.ravel()
         else:
-            if self.train_set.is_unk_user(user_id) or self.train_set.is_unk_item(item_id):
-                raise ScoreException("Can't make score prediction for (user_id=%d, item_id=%d)" % (user_id, item_id))
+            if self.train_set.is_unk_user(user_idx) or self.train_set.is_unk_item(item_idx):
+                raise ScoreException("Can't make score prediction for (user_id=%d, item_id=%d)" % (user_idx, item_idx))
 
             user_pred = self.sess.run(self.prediction, feed_dict={
-                self.gmf_user_id: [user_id], self.mlp_user_id: [user_id], self.item_id: [item_id]
+                self.gmf_user_id: [user_idx], self.mlp_user_id: [user_idx], self.item_id: [item_idx]
             })
             return user_pred.ravel()

--- a/cornac/models/ncf/recom_neumf.py
+++ b/cornac/models/ncf/recom_neumf.py
@@ -122,10 +122,10 @@ class NeuMF(Recommender):
 
         Parameters
         ----------
-        train_set: :obj:`cornac.data.MultimodalTrainSet`, required
+        train_set: :obj:`cornac.data.Dataset`, required
             User-Item preference data as well as additional modalities.
 
-        val_set: :obj:`cornac.data.MultimodalTestSet`, optional, default: None
+        val_set: :obj:`cornac.data.Dataset`, optional, default: None
             User-Item preference data for model selection purposes (e.g., early stopping).
 
         Returns

--- a/cornac/models/nmf/recom_nmf.cpp
+++ b/cornac/models/nmf/recom_nmf.cpp
@@ -2529,13 +2529,12 @@ static const char __pyx_k_float32[] = "float32";
 static const char __pyx_k_fortran[] = "fortran";
 static const char __pyx_k_get_rng[] = "get_rng";
 static const char __pyx_k_indices[] = "indices";
-static const char __pyx_k_item_id[] = "item_id";
+static const char __pyx_k_item_id[] = ", item_id=";
 static const char __pyx_k_memview[] = "memview";
 static const char __pyx_k_n_items[] = "n_items";
 static const char __pyx_k_n_users[] = "n_users";
 static const char __pyx_k_prepare[] = "__prepare__";
 static const char __pyx_k_uniform[] = "uniform";
-static const char __pyx_k_user_id[] = "user_id";
 static const char __pyx_k_val_set[] = "val_set";
 static const char __pyx_k_verbose[] = "verbose";
 static const char __pyx_k_Ellipsis[] = "Ellipsis";
@@ -2543,6 +2542,7 @@ static const char __pyx_k_defaults[] = "defaults";
 static const char __pyx_k_fast_dot[] = "fast_dot";
 static const char __pyx_k_getstate[] = "__getstate__";
 static const char __pyx_k_i_biases[] = "i_biases";
+static const char __pyx_k_item_idx[] = "item_idx";
 static const char __pyx_k_itemsize[] = "itemsize";
 static const char __pyx_k_lambda_u[] = "lambda_u";
 static const char __pyx_k_lambda_v[] = "lambda_v";
@@ -2556,6 +2556,7 @@ static const char __pyx_k_unk_item[] = "unk_item";
 static const char __pyx_k_unk_user[] = "unk_user";
 static const char __pyx_k_use_bias[] = "use_bias";
 static const char __pyx_k_user_ids[] = "user_ids";
+static const char __pyx_k_user_idx[] = "user_idx";
 static const char __pyx_k_NMF_score[] = "NMF.score";
 static const char __pyx_k_TypeError[] = "TypeError";
 static const char __pyx_k_cpu_count[] = "cpu_count";
@@ -2563,7 +2564,6 @@ static const char __pyx_k_enumerate[] = "enumerate";
 static const char __pyx_k_exception[] = "exception";
 static const char __pyx_k_i_factors[] = "i_factors";
 static const char __pyx_k_int_float[] = "int|float";
-static const char __pyx_k_item_id_2[] = ", item_id=";
 static const char __pyx_k_lambda_bi[] = "lambda_bi";
 static const char __pyx_k_lambda_bu[] = "lambda_bu";
 static const char __pyx_k_metaclass[] = "__metaclass__";
@@ -2789,8 +2789,8 @@ static PyObject *__pyx_kp_s_int_float;
 static PyObject *__pyx_n_s_is_unk_item;
 static PyObject *__pyx_n_s_is_unk_user;
 static PyObject *__pyx_n_s_item_counts;
-static PyObject *__pyx_n_s_item_id;
-static PyObject *__pyx_kp_u_item_id_2;
+static PyObject *__pyx_kp_u_item_id;
+static PyObject *__pyx_n_s_item_idx;
 static PyObject *__pyx_n_s_item_score;
 static PyObject *__pyx_n_s_itemsize;
 static PyObject *__pyx_kp_s_itemsize_0_for_cython_array;
@@ -2907,8 +2907,8 @@ static PyObject *__pyx_n_s_unpack;
 static PyObject *__pyx_n_s_update;
 static PyObject *__pyx_n_s_use_bias;
 static PyObject *__pyx_n_s_user_counts;
-static PyObject *__pyx_n_s_user_id;
 static PyObject *__pyx_n_s_user_ids;
+static PyObject *__pyx_n_s_user_idx;
 static PyObject *__pyx_n_s_utils;
 static PyObject *__pyx_n_s_utils_init_utils;
 static PyObject *__pyx_n_s_val;
@@ -2924,7 +2924,7 @@ static PyObject *__pyx_pf_6cornac_6models_3nmf_9recom_nmf_3NMF_12_fit_sgd(CYTHON
 static PyObject *__pyx_pf_6cornac_6models_3nmf_9recom_nmf_3NMF_14_fit_sgd(CYTHON_UNUSED PyObject *__pyx_self, PyObject *__pyx_v_self, __Pyx_memviewslice __pyx_v_rid, __Pyx_memviewslice __pyx_v_cid, __Pyx_memviewslice __pyx_v_val, __Pyx_memviewslice __pyx_v_user_counts, __Pyx_memviewslice __pyx_v_item_counts, __Pyx_memviewslice __pyx_v_U, __Pyx_memviewslice __pyx_v_V, __Pyx_memviewslice __pyx_v_Bu, __Pyx_memviewslice __pyx_v_Bi); /* proto */
 static PyObject *__pyx_pf_6cornac_6models_3nmf_9recom_nmf_3NMF_16_fit_sgd(CYTHON_UNUSED PyObject *__pyx_self, PyObject *__pyx_v_self, __Pyx_memviewslice __pyx_v_rid, __Pyx_memviewslice __pyx_v_cid, __Pyx_memviewslice __pyx_v_val, __Pyx_memviewslice __pyx_v_user_counts, __Pyx_memviewslice __pyx_v_item_counts, __Pyx_memviewslice __pyx_v_U, __Pyx_memviewslice __pyx_v_V, __Pyx_memviewslice __pyx_v_Bu, __Pyx_memviewslice __pyx_v_Bi); /* proto */
 static PyObject *__pyx_pf_6cornac_6models_3nmf_9recom_nmf_3NMF_18_fit_sgd(CYTHON_UNUSED PyObject *__pyx_self, PyObject *__pyx_v_self, __Pyx_memviewslice __pyx_v_rid, __Pyx_memviewslice __pyx_v_cid, __Pyx_memviewslice __pyx_v_val, __Pyx_memviewslice __pyx_v_user_counts, __Pyx_memviewslice __pyx_v_item_counts, __Pyx_memviewslice __pyx_v_U, __Pyx_memviewslice __pyx_v_V, __Pyx_memviewslice __pyx_v_Bu, __Pyx_memviewslice __pyx_v_Bi); /* proto */
-static PyObject *__pyx_pf_6cornac_6models_3nmf_9recom_nmf_3NMF_6score(CYTHON_UNUSED PyObject *__pyx_self, PyObject *__pyx_v_self, PyObject *__pyx_v_user_id, PyObject *__pyx_v_item_id); /* proto */
+static PyObject *__pyx_pf_6cornac_6models_3nmf_9recom_nmf_3NMF_6score(CYTHON_UNUSED PyObject *__pyx_self, PyObject *__pyx_v_self, PyObject *__pyx_v_user_idx, PyObject *__pyx_v_item_idx); /* proto */
 static int __pyx_pf_5numpy_7ndarray___getbuffer__(PyArrayObject *__pyx_v_self, Py_buffer *__pyx_v_info, int __pyx_v_flags); /* proto */
 static void __pyx_pf_5numpy_7ndarray_2__releasebuffer__(PyArrayObject *__pyx_v_self, Py_buffer *__pyx_v_info); /* proto */
 static int __pyx_array___pyx_pf_15View_dot_MemoryView_5array___cinit__(struct __pyx_array_obj *__pyx_v_self, PyObject *__pyx_v_shape, Py_ssize_t __pyx_v_itemsize, PyObject *__pyx_v_format, PyObject *__pyx_v_mode, int __pyx_v_allocate_buffer); /* proto */
@@ -3611,7 +3611,7 @@ static PyObject *__pyx_pf_6cornac_6models_3nmf_9recom_nmf_3NMF___init__(CYTHON_U
 
 /* Python wrapper */
 static PyObject *__pyx_pw_6cornac_6models_3nmf_9recom_nmf_3NMF_3fit(PyObject *__pyx_self, PyObject *__pyx_args, PyObject *__pyx_kwds); /*proto*/
-static char __pyx_doc_6cornac_6models_3nmf_9recom_nmf_3NMF_2fit[] = "Fit the model to observations.\n\n        Parameters\n        ----------\n        train_set: :obj:`cornac.data.MultimodalTrainSet`, required\n            User-Item preference data as well as additional modalities.\n\n        val_set: :obj:`cornac.data.MultimodalTestSet`, optional, default: None\n            User-Item preference data for model selection purposes (e.g., early stopping).\n\n        Returns\n        -------\n        self : object\n        ";
+static char __pyx_doc_6cornac_6models_3nmf_9recom_nmf_3NMF_2fit[] = "Fit the model to observations.\n\n        Parameters\n        ----------\n        train_set: :obj:`cornac.data.Dataset`, required\n            User-Item preference data as well as additional modalities.\n\n        val_set: :obj:`cornac.data.Dataset`, optional, default: None\n            User-Item preference data for model selection purposes (e.g., early stopping).\n\n        Returns\n        -------\n        self : object\n        ";
 static PyMethodDef __pyx_mdef_6cornac_6models_3nmf_9recom_nmf_3NMF_3fit = {"fit", (PyCFunction)(void*)(PyCFunctionWithKeywords)__pyx_pw_6cornac_6models_3nmf_9recom_nmf_3NMF_3fit, METH_VARARGS|METH_KEYWORDS, __pyx_doc_6cornac_6models_3nmf_9recom_nmf_3NMF_2fit};
 static PyObject *__pyx_pw_6cornac_6models_3nmf_9recom_nmf_3NMF_3fit(PyObject *__pyx_self, PyObject *__pyx_args, PyObject *__pyx_kwds) {
   PyObject *__pyx_v_self = 0;
@@ -16463,24 +16463,24 @@ static PyObject *__pyx_pf_6cornac_6models_3nmf_9recom_nmf_3NMF_18_fit_sgd(CYTHON
 /* "cornac/models/nmf/recom_nmf.pyx":239
  * 
  * 
- *     def score(self, user_id, item_id=None):             # <<<<<<<<<<<<<<
+ *     def score(self, user_idx, item_idx=None):             # <<<<<<<<<<<<<<
  *         """Predict the scores/ratings of a user for an item.
  * 
  */
 
 /* Python wrapper */
 static PyObject *__pyx_pw_6cornac_6models_3nmf_9recom_nmf_3NMF_7score(PyObject *__pyx_self, PyObject *__pyx_args, PyObject *__pyx_kwds); /*proto*/
-static char __pyx_doc_6cornac_6models_3nmf_9recom_nmf_3NMF_6score[] = "Predict the scores/ratings of a user for an item.\n\n        Parameters\n        ----------\n        user_id: int, required\n            The index of the user for whom to perform score prediction.\n\n        item_id: int, optional, default: None\n            The index of the item for that to perform score prediction.\n            If None, scores for all known items will be returned.\n\n        Returns\n        -------\n        res : A scalar or a Numpy array\n            Relative scores that the user gives to the item or to all known items\n\n        ";
+static char __pyx_doc_6cornac_6models_3nmf_9recom_nmf_3NMF_6score[] = "Predict the scores/ratings of a user for an item.\n\n        Parameters\n        ----------\n        user_idx: int, required\n            The index of the user for whom to perform score prediction.\n\n        item_idx: int, optional, default: None\n            The index of the item for that to perform score prediction.\n            If None, scores for all known items will be returned.\n\n        Returns\n        -------\n        res : A scalar or a Numpy array\n            Relative scores that the user gives to the item or to all known items\n\n        ";
 static PyMethodDef __pyx_mdef_6cornac_6models_3nmf_9recom_nmf_3NMF_7score = {"score", (PyCFunction)(void*)(PyCFunctionWithKeywords)__pyx_pw_6cornac_6models_3nmf_9recom_nmf_3NMF_7score, METH_VARARGS|METH_KEYWORDS, __pyx_doc_6cornac_6models_3nmf_9recom_nmf_3NMF_6score};
 static PyObject *__pyx_pw_6cornac_6models_3nmf_9recom_nmf_3NMF_7score(PyObject *__pyx_self, PyObject *__pyx_args, PyObject *__pyx_kwds) {
   PyObject *__pyx_v_self = 0;
-  PyObject *__pyx_v_user_id = 0;
-  PyObject *__pyx_v_item_id = 0;
+  PyObject *__pyx_v_user_idx = 0;
+  PyObject *__pyx_v_item_idx = 0;
   PyObject *__pyx_r = 0;
   __Pyx_RefNannyDeclarations
   __Pyx_RefNannySetupContext("score (wrapper)", 0);
   {
-    static PyObject **__pyx_pyargnames[] = {&__pyx_n_s_self,&__pyx_n_s_user_id,&__pyx_n_s_item_id,0};
+    static PyObject **__pyx_pyargnames[] = {&__pyx_n_s_self,&__pyx_n_s_user_idx,&__pyx_n_s_item_idx,0};
     PyObject* values[3] = {0,0,0};
     values[2] = ((PyObject *)((PyObject *)Py_None));
     if (unlikely(__pyx_kwds)) {
@@ -16503,14 +16503,14 @@ static PyObject *__pyx_pw_6cornac_6models_3nmf_9recom_nmf_3NMF_7score(PyObject *
         else goto __pyx_L5_argtuple_error;
         CYTHON_FALLTHROUGH;
         case  1:
-        if (likely((values[1] = __Pyx_PyDict_GetItemStr(__pyx_kwds, __pyx_n_s_user_id)) != 0)) kw_args--;
+        if (likely((values[1] = __Pyx_PyDict_GetItemStr(__pyx_kwds, __pyx_n_s_user_idx)) != 0)) kw_args--;
         else {
           __Pyx_RaiseArgtupleInvalid("score", 0, 2, 3, 1); __PYX_ERR(0, 239, __pyx_L3_error)
         }
         CYTHON_FALLTHROUGH;
         case  2:
         if (kw_args > 0) {
-          PyObject* value = __Pyx_PyDict_GetItemStr(__pyx_kwds, __pyx_n_s_item_id);
+          PyObject* value = __Pyx_PyDict_GetItemStr(__pyx_kwds, __pyx_n_s_item_idx);
           if (value) { values[2] = value; kw_args--; }
         }
       }
@@ -16528,8 +16528,8 @@ static PyObject *__pyx_pw_6cornac_6models_3nmf_9recom_nmf_3NMF_7score(PyObject *
       }
     }
     __pyx_v_self = values[0];
-    __pyx_v_user_id = values[1];
-    __pyx_v_item_id = values[2];
+    __pyx_v_user_idx = values[1];
+    __pyx_v_item_idx = values[2];
   }
   goto __pyx_L4_argument_unpacking_done;
   __pyx_L5_argtuple_error:;
@@ -16539,14 +16539,14 @@ static PyObject *__pyx_pw_6cornac_6models_3nmf_9recom_nmf_3NMF_7score(PyObject *
   __Pyx_RefNannyFinishContext();
   return NULL;
   __pyx_L4_argument_unpacking_done:;
-  __pyx_r = __pyx_pf_6cornac_6models_3nmf_9recom_nmf_3NMF_6score(__pyx_self, __pyx_v_self, __pyx_v_user_id, __pyx_v_item_id);
+  __pyx_r = __pyx_pf_6cornac_6models_3nmf_9recom_nmf_3NMF_6score(__pyx_self, __pyx_v_self, __pyx_v_user_idx, __pyx_v_item_idx);
 
   /* function exit code */
   __Pyx_RefNannyFinishContext();
   return __pyx_r;
 }
 
-static PyObject *__pyx_pf_6cornac_6models_3nmf_9recom_nmf_3NMF_6score(CYTHON_UNUSED PyObject *__pyx_self, PyObject *__pyx_v_self, PyObject *__pyx_v_user_id, PyObject *__pyx_v_item_id) {
+static PyObject *__pyx_pf_6cornac_6models_3nmf_9recom_nmf_3NMF_6score(CYTHON_UNUSED PyObject *__pyx_self, PyObject *__pyx_v_self, PyObject *__pyx_v_user_idx, PyObject *__pyx_v_item_idx) {
   PyObject *__pyx_v_unk_user = NULL;
   PyObject *__pyx_v_known_item_scores = NULL;
   PyObject *__pyx_v_unk_item = NULL;
@@ -16570,9 +16570,9 @@ static PyObject *__pyx_pf_6cornac_6models_3nmf_9recom_nmf_3NMF_6score(CYTHON_UNU
   /* "cornac/models/nmf/recom_nmf.pyx":257
  * 
  *         """
- *         unk_user = self.train_set.is_unk_user(user_id)             # <<<<<<<<<<<<<<
+ *         unk_user = self.train_set.is_unk_user(user_idx)             # <<<<<<<<<<<<<<
  * 
- *         if item_id is None:
+ *         if item_idx is None:
  */
   __pyx_t_2 = __Pyx_PyObject_GetAttrStr(__pyx_v_self, __pyx_n_s_train_set); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 257, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_2);
@@ -16589,7 +16589,7 @@ static PyObject *__pyx_pf_6cornac_6models_3nmf_9recom_nmf_3NMF_6score(CYTHON_UNU
       __Pyx_DECREF_SET(__pyx_t_3, function);
     }
   }
-  __pyx_t_1 = (__pyx_t_2) ? __Pyx_PyObject_Call2Args(__pyx_t_3, __pyx_t_2, __pyx_v_user_id) : __Pyx_PyObject_CallOneArg(__pyx_t_3, __pyx_v_user_id);
+  __pyx_t_1 = (__pyx_t_2) ? __Pyx_PyObject_Call2Args(__pyx_t_3, __pyx_t_2, __pyx_v_user_idx) : __Pyx_PyObject_CallOneArg(__pyx_t_3, __pyx_v_user_idx);
   __Pyx_XDECREF(__pyx_t_2); __pyx_t_2 = 0;
   if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 257, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
@@ -16598,22 +16598,22 @@ static PyObject *__pyx_pf_6cornac_6models_3nmf_9recom_nmf_3NMF_6score(CYTHON_UNU
   __pyx_t_1 = 0;
 
   /* "cornac/models/nmf/recom_nmf.pyx":259
- *         unk_user = self.train_set.is_unk_user(user_id)
+ *         unk_user = self.train_set.is_unk_user(user_idx)
  * 
- *         if item_id is None:             # <<<<<<<<<<<<<<
+ *         if item_idx is None:             # <<<<<<<<<<<<<<
  *             known_item_scores = np.add(self.i_biases, self.global_mean)
  *             if not unk_user:
  */
-  __pyx_t_4 = (__pyx_v_item_id == Py_None);
+  __pyx_t_4 = (__pyx_v_item_idx == Py_None);
   __pyx_t_5 = (__pyx_t_4 != 0);
   if (__pyx_t_5) {
 
     /* "cornac/models/nmf/recom_nmf.pyx":260
  * 
- *         if item_id is None:
+ *         if item_idx is None:
  *             known_item_scores = np.add(self.i_biases, self.global_mean)             # <<<<<<<<<<<<<<
  *             if not unk_user:
- *                 known_item_scores = np.add(known_item_scores, self.u_biases[user_id])
+ *                 known_item_scores = np.add(known_item_scores, self.u_biases[user_idx])
  */
     __Pyx_GetModuleGlobalName(__pyx_t_3, __pyx_n_s_np); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 260, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_3);
@@ -16677,11 +16677,11 @@ static PyObject *__pyx_pf_6cornac_6models_3nmf_9recom_nmf_3NMF_6score(CYTHON_UNU
     __pyx_t_1 = 0;
 
     /* "cornac/models/nmf/recom_nmf.pyx":261
- *         if item_id is None:
+ *         if item_idx is None:
  *             known_item_scores = np.add(self.i_biases, self.global_mean)
  *             if not unk_user:             # <<<<<<<<<<<<<<
- *                 known_item_scores = np.add(known_item_scores, self.u_biases[user_id])
- *                 fast_dot(self.u_factors[user_id], self.i_factors, known_item_scores)
+ *                 known_item_scores = np.add(known_item_scores, self.u_biases[user_idx])
+ *                 fast_dot(self.u_factors[user_idx], self.i_factors, known_item_scores)
  */
     __pyx_t_5 = __Pyx_PyObject_IsTrue(__pyx_v_unk_user); if (unlikely(__pyx_t_5 < 0)) __PYX_ERR(0, 261, __pyx_L1_error)
     __pyx_t_4 = ((!__pyx_t_5) != 0);
@@ -16690,8 +16690,8 @@ static PyObject *__pyx_pf_6cornac_6models_3nmf_9recom_nmf_3NMF_6score(CYTHON_UNU
       /* "cornac/models/nmf/recom_nmf.pyx":262
  *             known_item_scores = np.add(self.i_biases, self.global_mean)
  *             if not unk_user:
- *                 known_item_scores = np.add(known_item_scores, self.u_biases[user_id])             # <<<<<<<<<<<<<<
- *                 fast_dot(self.u_factors[user_id], self.i_factors, known_item_scores)
+ *                 known_item_scores = np.add(known_item_scores, self.u_biases[user_idx])             # <<<<<<<<<<<<<<
+ *                 fast_dot(self.u_factors[user_idx], self.i_factors, known_item_scores)
  *             return known_item_scores
  */
       __Pyx_GetModuleGlobalName(__pyx_t_2, __pyx_n_s_np); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 262, __pyx_L1_error)
@@ -16701,7 +16701,7 @@ static PyObject *__pyx_pf_6cornac_6models_3nmf_9recom_nmf_3NMF_6score(CYTHON_UNU
       __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
       __pyx_t_2 = __Pyx_PyObject_GetAttrStr(__pyx_v_self, __pyx_n_s_u_biases); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 262, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_2);
-      __pyx_t_6 = __Pyx_PyObject_GetItem(__pyx_t_2, __pyx_v_user_id); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 262, __pyx_L1_error)
+      __pyx_t_6 = __Pyx_PyObject_GetItem(__pyx_t_2, __pyx_v_user_idx); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 262, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_6);
       __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
       __pyx_t_2 = NULL;
@@ -16756,8 +16756,8 @@ static PyObject *__pyx_pf_6cornac_6models_3nmf_9recom_nmf_3NMF_6score(CYTHON_UNU
 
       /* "cornac/models/nmf/recom_nmf.pyx":263
  *             if not unk_user:
- *                 known_item_scores = np.add(known_item_scores, self.u_biases[user_id])
- *                 fast_dot(self.u_factors[user_id], self.i_factors, known_item_scores)             # <<<<<<<<<<<<<<
+ *                 known_item_scores = np.add(known_item_scores, self.u_biases[user_idx])
+ *                 fast_dot(self.u_factors[user_idx], self.i_factors, known_item_scores)             # <<<<<<<<<<<<<<
  *             return known_item_scores
  *         else:
  */
@@ -16765,7 +16765,7 @@ static PyObject *__pyx_pf_6cornac_6models_3nmf_9recom_nmf_3NMF_6score(CYTHON_UNU
       __Pyx_GOTREF(__pyx_t_9);
       __pyx_t_3 = __Pyx_PyObject_GetAttrStr(__pyx_v_self, __pyx_n_s_u_factors); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 263, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_3);
-      __pyx_t_6 = __Pyx_PyObject_GetItem(__pyx_t_3, __pyx_v_user_id); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 263, __pyx_L1_error)
+      __pyx_t_6 = __Pyx_PyObject_GetItem(__pyx_t_3, __pyx_v_user_idx); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 263, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_6);
       __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
       __pyx_t_3 = __Pyx_PyObject_GetAttrStr(__pyx_v_self, __pyx_n_s_i_factors); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 263, __pyx_L1_error)
@@ -16825,20 +16825,20 @@ static PyObject *__pyx_pf_6cornac_6models_3nmf_9recom_nmf_3NMF_6score(CYTHON_UNU
       __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
 
       /* "cornac/models/nmf/recom_nmf.pyx":261
- *         if item_id is None:
+ *         if item_idx is None:
  *             known_item_scores = np.add(self.i_biases, self.global_mean)
  *             if not unk_user:             # <<<<<<<<<<<<<<
- *                 known_item_scores = np.add(known_item_scores, self.u_biases[user_id])
- *                 fast_dot(self.u_factors[user_id], self.i_factors, known_item_scores)
+ *                 known_item_scores = np.add(known_item_scores, self.u_biases[user_idx])
+ *                 fast_dot(self.u_factors[user_idx], self.i_factors, known_item_scores)
  */
     }
 
     /* "cornac/models/nmf/recom_nmf.pyx":264
- *                 known_item_scores = np.add(known_item_scores, self.u_biases[user_id])
- *                 fast_dot(self.u_factors[user_id], self.i_factors, known_item_scores)
+ *                 known_item_scores = np.add(known_item_scores, self.u_biases[user_idx])
+ *                 fast_dot(self.u_factors[user_idx], self.i_factors, known_item_scores)
  *             return known_item_scores             # <<<<<<<<<<<<<<
  *         else:
- *             unk_item = self.train_set.is_unk_item(item_id)
+ *             unk_item = self.train_set.is_unk_item(item_idx)
  */
     __Pyx_XDECREF(__pyx_r);
     __Pyx_INCREF(__pyx_v_known_item_scores);
@@ -16846,9 +16846,9 @@ static PyObject *__pyx_pf_6cornac_6models_3nmf_9recom_nmf_3NMF_6score(CYTHON_UNU
     goto __pyx_L0;
 
     /* "cornac/models/nmf/recom_nmf.pyx":259
- *         unk_user = self.train_set.is_unk_user(user_id)
+ *         unk_user = self.train_set.is_unk_user(user_idx)
  * 
- *         if item_id is None:             # <<<<<<<<<<<<<<
+ *         if item_idx is None:             # <<<<<<<<<<<<<<
  *             known_item_scores = np.add(self.i_biases, self.global_mean)
  *             if not unk_user:
  */
@@ -16857,7 +16857,7 @@ static PyObject *__pyx_pf_6cornac_6models_3nmf_9recom_nmf_3NMF_6score(CYTHON_UNU
   /* "cornac/models/nmf/recom_nmf.pyx":266
  *             return known_item_scores
  *         else:
- *             unk_item = self.train_set.is_unk_item(item_id)             # <<<<<<<<<<<<<<
+ *             unk_item = self.train_set.is_unk_item(item_idx)             # <<<<<<<<<<<<<<
  *             if self.use_bias:
  *                 item_score = self.global_mean
  */
@@ -16877,7 +16877,7 @@ static PyObject *__pyx_pf_6cornac_6models_3nmf_9recom_nmf_3NMF_6score(CYTHON_UNU
         __Pyx_DECREF_SET(__pyx_t_7, function);
       }
     }
-    __pyx_t_1 = (__pyx_t_9) ? __Pyx_PyObject_Call2Args(__pyx_t_7, __pyx_t_9, __pyx_v_item_id) : __Pyx_PyObject_CallOneArg(__pyx_t_7, __pyx_v_item_id);
+    __pyx_t_1 = (__pyx_t_9) ? __Pyx_PyObject_Call2Args(__pyx_t_7, __pyx_t_9, __pyx_v_item_idx) : __Pyx_PyObject_CallOneArg(__pyx_t_7, __pyx_v_item_idx);
     __Pyx_XDECREF(__pyx_t_9); __pyx_t_9 = 0;
     if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 266, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_1);
@@ -16887,7 +16887,7 @@ static PyObject *__pyx_pf_6cornac_6models_3nmf_9recom_nmf_3NMF_6score(CYTHON_UNU
 
     /* "cornac/models/nmf/recom_nmf.pyx":267
  *         else:
- *             unk_item = self.train_set.is_unk_item(item_id)
+ *             unk_item = self.train_set.is_unk_item(item_idx)
  *             if self.use_bias:             # <<<<<<<<<<<<<<
  *                 item_score = self.global_mean
  *                 if not unk_user:
@@ -16899,11 +16899,11 @@ static PyObject *__pyx_pf_6cornac_6models_3nmf_9recom_nmf_3NMF_6score(CYTHON_UNU
     if (__pyx_t_4) {
 
       /* "cornac/models/nmf/recom_nmf.pyx":268
- *             unk_item = self.train_set.is_unk_item(item_id)
+ *             unk_item = self.train_set.is_unk_item(item_idx)
  *             if self.use_bias:
  *                 item_score = self.global_mean             # <<<<<<<<<<<<<<
  *                 if not unk_user:
- *                     item_score += self.u_biases[user_id]
+ *                     item_score += self.u_biases[user_idx]
  */
       __pyx_t_1 = __Pyx_PyObject_GetAttrStr(__pyx_v_self, __pyx_n_s_global_mean); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 268, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_1);
@@ -16914,7 +16914,7 @@ static PyObject *__pyx_pf_6cornac_6models_3nmf_9recom_nmf_3NMF_6score(CYTHON_UNU
  *             if self.use_bias:
  *                 item_score = self.global_mean
  *                 if not unk_user:             # <<<<<<<<<<<<<<
- *                     item_score += self.u_biases[user_id]
+ *                     item_score += self.u_biases[user_idx]
  *                 if not unk_item:
  */
       __pyx_t_4 = __Pyx_PyObject_IsTrue(__pyx_v_unk_user); if (unlikely(__pyx_t_4 < 0)) __PYX_ERR(0, 269, __pyx_L1_error)
@@ -16924,13 +16924,13 @@ static PyObject *__pyx_pf_6cornac_6models_3nmf_9recom_nmf_3NMF_6score(CYTHON_UNU
         /* "cornac/models/nmf/recom_nmf.pyx":270
  *                 item_score = self.global_mean
  *                 if not unk_user:
- *                     item_score += self.u_biases[user_id]             # <<<<<<<<<<<<<<
+ *                     item_score += self.u_biases[user_idx]             # <<<<<<<<<<<<<<
  *                 if not unk_item:
- *                     item_score += self.i_biases[item_id]
+ *                     item_score += self.i_biases[item_idx]
  */
         __pyx_t_1 = __Pyx_PyObject_GetAttrStr(__pyx_v_self, __pyx_n_s_u_biases); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 270, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_1);
-        __pyx_t_7 = __Pyx_PyObject_GetItem(__pyx_t_1, __pyx_v_user_id); if (unlikely(!__pyx_t_7)) __PYX_ERR(0, 270, __pyx_L1_error)
+        __pyx_t_7 = __Pyx_PyObject_GetItem(__pyx_t_1, __pyx_v_user_idx); if (unlikely(!__pyx_t_7)) __PYX_ERR(0, 270, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_7);
         __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
         __pyx_t_1 = PyNumber_InPlaceAdd(__pyx_v_item_score, __pyx_t_7); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 270, __pyx_L1_error)
@@ -16943,16 +16943,16 @@ static PyObject *__pyx_pf_6cornac_6models_3nmf_9recom_nmf_3NMF_6score(CYTHON_UNU
  *             if self.use_bias:
  *                 item_score = self.global_mean
  *                 if not unk_user:             # <<<<<<<<<<<<<<
- *                     item_score += self.u_biases[user_id]
+ *                     item_score += self.u_biases[user_idx]
  *                 if not unk_item:
  */
       }
 
       /* "cornac/models/nmf/recom_nmf.pyx":271
  *                 if not unk_user:
- *                     item_score += self.u_biases[user_id]
+ *                     item_score += self.u_biases[user_idx]
  *                 if not unk_item:             # <<<<<<<<<<<<<<
- *                     item_score += self.i_biases[item_id]
+ *                     item_score += self.i_biases[item_idx]
  *                 if not unk_user and not unk_item:
  */
       __pyx_t_5 = __Pyx_PyObject_IsTrue(__pyx_v_unk_item); if (unlikely(__pyx_t_5 < 0)) __PYX_ERR(0, 271, __pyx_L1_error)
@@ -16960,15 +16960,15 @@ static PyObject *__pyx_pf_6cornac_6models_3nmf_9recom_nmf_3NMF_6score(CYTHON_UNU
       if (__pyx_t_4) {
 
         /* "cornac/models/nmf/recom_nmf.pyx":272
- *                     item_score += self.u_biases[user_id]
+ *                     item_score += self.u_biases[user_idx]
  *                 if not unk_item:
- *                     item_score += self.i_biases[item_id]             # <<<<<<<<<<<<<<
+ *                     item_score += self.i_biases[item_idx]             # <<<<<<<<<<<<<<
  *                 if not unk_user and not unk_item:
- *                     item_score += np.dot(self.u_factors[user_id], self.i_factors[item_id])
+ *                     item_score += np.dot(self.u_factors[user_idx], self.i_factors[item_idx])
  */
         __pyx_t_1 = __Pyx_PyObject_GetAttrStr(__pyx_v_self, __pyx_n_s_i_biases); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 272, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_1);
-        __pyx_t_7 = __Pyx_PyObject_GetItem(__pyx_t_1, __pyx_v_item_id); if (unlikely(!__pyx_t_7)) __PYX_ERR(0, 272, __pyx_L1_error)
+        __pyx_t_7 = __Pyx_PyObject_GetItem(__pyx_t_1, __pyx_v_item_idx); if (unlikely(!__pyx_t_7)) __PYX_ERR(0, 272, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_7);
         __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
         __pyx_t_1 = PyNumber_InPlaceAdd(__pyx_v_item_score, __pyx_t_7); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 272, __pyx_L1_error)
@@ -16979,18 +16979,18 @@ static PyObject *__pyx_pf_6cornac_6models_3nmf_9recom_nmf_3NMF_6score(CYTHON_UNU
 
         /* "cornac/models/nmf/recom_nmf.pyx":271
  *                 if not unk_user:
- *                     item_score += self.u_biases[user_id]
+ *                     item_score += self.u_biases[user_idx]
  *                 if not unk_item:             # <<<<<<<<<<<<<<
- *                     item_score += self.i_biases[item_id]
+ *                     item_score += self.i_biases[item_idx]
  *                 if not unk_user and not unk_item:
  */
       }
 
       /* "cornac/models/nmf/recom_nmf.pyx":273
  *                 if not unk_item:
- *                     item_score += self.i_biases[item_id]
+ *                     item_score += self.i_biases[item_idx]
  *                 if not unk_user and not unk_item:             # <<<<<<<<<<<<<<
- *                     item_score += np.dot(self.u_factors[user_id], self.i_factors[item_id])
+ *                     item_score += np.dot(self.u_factors[user_idx], self.i_factors[item_idx])
  *             else:
  */
       __pyx_t_5 = __Pyx_PyObject_IsTrue(__pyx_v_unk_user); if (unlikely(__pyx_t_5 < 0)) __PYX_ERR(0, 273, __pyx_L1_error)
@@ -17007,9 +17007,9 @@ static PyObject *__pyx_pf_6cornac_6models_3nmf_9recom_nmf_3NMF_6score(CYTHON_UNU
       if (__pyx_t_4) {
 
         /* "cornac/models/nmf/recom_nmf.pyx":274
- *                     item_score += self.i_biases[item_id]
+ *                     item_score += self.i_biases[item_idx]
  *                 if not unk_user and not unk_item:
- *                     item_score += np.dot(self.u_factors[user_id], self.i_factors[item_id])             # <<<<<<<<<<<<<<
+ *                     item_score += np.dot(self.u_factors[user_idx], self.i_factors[item_idx])             # <<<<<<<<<<<<<<
  *             else:
  *                 if unk_user or unk_item:
  */
@@ -17020,12 +17020,12 @@ static PyObject *__pyx_pf_6cornac_6models_3nmf_9recom_nmf_3NMF_6score(CYTHON_UNU
         __Pyx_DECREF(__pyx_t_7); __pyx_t_7 = 0;
         __pyx_t_7 = __Pyx_PyObject_GetAttrStr(__pyx_v_self, __pyx_n_s_u_factors); if (unlikely(!__pyx_t_7)) __PYX_ERR(0, 274, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_7);
-        __pyx_t_3 = __Pyx_PyObject_GetItem(__pyx_t_7, __pyx_v_user_id); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 274, __pyx_L1_error)
+        __pyx_t_3 = __Pyx_PyObject_GetItem(__pyx_t_7, __pyx_v_user_idx); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 274, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_3);
         __Pyx_DECREF(__pyx_t_7); __pyx_t_7 = 0;
         __pyx_t_7 = __Pyx_PyObject_GetAttrStr(__pyx_v_self, __pyx_n_s_i_factors); if (unlikely(!__pyx_t_7)) __PYX_ERR(0, 274, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_7);
-        __pyx_t_6 = __Pyx_PyObject_GetItem(__pyx_t_7, __pyx_v_item_id); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 274, __pyx_L1_error)
+        __pyx_t_6 = __Pyx_PyObject_GetItem(__pyx_t_7, __pyx_v_item_idx); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 274, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_6);
         __Pyx_DECREF(__pyx_t_7); __pyx_t_7 = 0;
         __pyx_t_7 = NULL;
@@ -17085,16 +17085,16 @@ static PyObject *__pyx_pf_6cornac_6models_3nmf_9recom_nmf_3NMF_6score(CYTHON_UNU
 
         /* "cornac/models/nmf/recom_nmf.pyx":273
  *                 if not unk_item:
- *                     item_score += self.i_biases[item_id]
+ *                     item_score += self.i_biases[item_idx]
  *                 if not unk_user and not unk_item:             # <<<<<<<<<<<<<<
- *                     item_score += np.dot(self.u_factors[user_id], self.i_factors[item_id])
+ *                     item_score += np.dot(self.u_factors[user_idx], self.i_factors[item_idx])
  *             else:
  */
       }
 
       /* "cornac/models/nmf/recom_nmf.pyx":267
  *         else:
- *             unk_item = self.train_set.is_unk_item(item_id)
+ *             unk_item = self.train_set.is_unk_item(item_idx)
  *             if self.use_bias:             # <<<<<<<<<<<<<<
  *                 item_score = self.global_mean
  *                 if not unk_user:
@@ -17103,11 +17103,11 @@ static PyObject *__pyx_pf_6cornac_6models_3nmf_9recom_nmf_3NMF_6score(CYTHON_UNU
     }
 
     /* "cornac/models/nmf/recom_nmf.pyx":276
- *                     item_score += np.dot(self.u_factors[user_id], self.i_factors[item_id])
+ *                     item_score += np.dot(self.u_factors[user_idx], self.i_factors[item_idx])
  *             else:
  *                 if unk_user or unk_item:             # <<<<<<<<<<<<<<
- *                     raise ScoreException("Can't make score prediction for (user_id=%d, item_id=%d)" % (user_id, item_id))
- *                 item_score = np.dot(self.u_factors[user_id], self.i_factors[item_id])
+ *                     raise ScoreException("Can't make score prediction for (user_id=%d, item_id=%d)" % (user_idx, item_idx))
+ *                 item_score = np.dot(self.u_factors[user_idx], self.i_factors[item_idx])
  */
     /*else*/ {
       __pyx_t_5 = __Pyx_PyObject_IsTrue(__pyx_v_unk_user); if (unlikely(__pyx_t_5 < 0)) __PYX_ERR(0, 276, __pyx_L1_error)
@@ -17124,8 +17124,8 @@ static PyObject *__pyx_pf_6cornac_6models_3nmf_9recom_nmf_3NMF_6score(CYTHON_UNU
         /* "cornac/models/nmf/recom_nmf.pyx":277
  *             else:
  *                 if unk_user or unk_item:
- *                     raise ScoreException("Can't make score prediction for (user_id=%d, item_id=%d)" % (user_id, item_id))             # <<<<<<<<<<<<<<
- *                 item_score = np.dot(self.u_factors[user_id], self.i_factors[item_id])
+ *                     raise ScoreException("Can't make score prediction for (user_id=%d, item_id=%d)" % (user_idx, item_idx))             # <<<<<<<<<<<<<<
+ *                 item_score = np.dot(self.u_factors[user_idx], self.i_factors[item_idx])
  *             return item_score
  */
         __Pyx_GetModuleGlobalName(__pyx_t_1, __pyx_n_s_ScoreException); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 277, __pyx_L1_error)
@@ -17138,18 +17138,18 @@ static PyObject *__pyx_pf_6cornac_6models_3nmf_9recom_nmf_3NMF_6score(CYTHON_UNU
         __pyx_t_11 += 41;
         __Pyx_GIVEREF(__pyx_kp_u_Can_t_make_score_prediction_for);
         PyTuple_SET_ITEM(__pyx_t_2, 0, __pyx_kp_u_Can_t_make_score_prediction_for);
-        __pyx_t_6 = __Pyx_PyObject_Format(__pyx_v_user_id, __pyx_n_u_d); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 277, __pyx_L1_error)
+        __pyx_t_6 = __Pyx_PyObject_Format(__pyx_v_user_idx, __pyx_n_u_d); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 277, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_6);
         __pyx_t_12 = (__Pyx_PyUnicode_MAX_CHAR_VALUE(__pyx_t_6) > __pyx_t_12) ? __Pyx_PyUnicode_MAX_CHAR_VALUE(__pyx_t_6) : __pyx_t_12;
         __pyx_t_11 += __Pyx_PyUnicode_GET_LENGTH(__pyx_t_6);
         __Pyx_GIVEREF(__pyx_t_6);
         PyTuple_SET_ITEM(__pyx_t_2, 1, __pyx_t_6);
         __pyx_t_6 = 0;
-        __Pyx_INCREF(__pyx_kp_u_item_id_2);
+        __Pyx_INCREF(__pyx_kp_u_item_id);
         __pyx_t_11 += 10;
-        __Pyx_GIVEREF(__pyx_kp_u_item_id_2);
-        PyTuple_SET_ITEM(__pyx_t_2, 2, __pyx_kp_u_item_id_2);
-        __pyx_t_6 = __Pyx_PyObject_Format(__pyx_v_item_id, __pyx_n_u_d); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 277, __pyx_L1_error)
+        __Pyx_GIVEREF(__pyx_kp_u_item_id);
+        PyTuple_SET_ITEM(__pyx_t_2, 2, __pyx_kp_u_item_id);
+        __pyx_t_6 = __Pyx_PyObject_Format(__pyx_v_item_idx, __pyx_n_u_d); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 277, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_6);
         __pyx_t_12 = (__Pyx_PyUnicode_MAX_CHAR_VALUE(__pyx_t_6) > __pyx_t_12) ? __Pyx_PyUnicode_MAX_CHAR_VALUE(__pyx_t_6) : __pyx_t_12;
         __pyx_t_11 += __Pyx_PyUnicode_GET_LENGTH(__pyx_t_6);
@@ -17184,18 +17184,18 @@ static PyObject *__pyx_pf_6cornac_6models_3nmf_9recom_nmf_3NMF_6score(CYTHON_UNU
         __PYX_ERR(0, 277, __pyx_L1_error)
 
         /* "cornac/models/nmf/recom_nmf.pyx":276
- *                     item_score += np.dot(self.u_factors[user_id], self.i_factors[item_id])
+ *                     item_score += np.dot(self.u_factors[user_idx], self.i_factors[item_idx])
  *             else:
  *                 if unk_user or unk_item:             # <<<<<<<<<<<<<<
- *                     raise ScoreException("Can't make score prediction for (user_id=%d, item_id=%d)" % (user_id, item_id))
- *                 item_score = np.dot(self.u_factors[user_id], self.i_factors[item_id])
+ *                     raise ScoreException("Can't make score prediction for (user_id=%d, item_id=%d)" % (user_idx, item_idx))
+ *                 item_score = np.dot(self.u_factors[user_idx], self.i_factors[item_idx])
  */
       }
 
       /* "cornac/models/nmf/recom_nmf.pyx":278
  *                 if unk_user or unk_item:
- *                     raise ScoreException("Can't make score prediction for (user_id=%d, item_id=%d)" % (user_id, item_id))
- *                 item_score = np.dot(self.u_factors[user_id], self.i_factors[item_id])             # <<<<<<<<<<<<<<
+ *                     raise ScoreException("Can't make score prediction for (user_id=%d, item_id=%d)" % (user_idx, item_idx))
+ *                 item_score = np.dot(self.u_factors[user_idx], self.i_factors[item_idx])             # <<<<<<<<<<<<<<
  *             return item_score
  */
       __Pyx_GetModuleGlobalName(__pyx_t_1, __pyx_n_s_np); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 278, __pyx_L1_error)
@@ -17205,12 +17205,12 @@ static PyObject *__pyx_pf_6cornac_6models_3nmf_9recom_nmf_3NMF_6score(CYTHON_UNU
       __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
       __pyx_t_1 = __Pyx_PyObject_GetAttrStr(__pyx_v_self, __pyx_n_s_u_factors); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 278, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_1);
-      __pyx_t_2 = __Pyx_PyObject_GetItem(__pyx_t_1, __pyx_v_user_id); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 278, __pyx_L1_error)
+      __pyx_t_2 = __Pyx_PyObject_GetItem(__pyx_t_1, __pyx_v_user_idx); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 278, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_2);
       __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
       __pyx_t_1 = __Pyx_PyObject_GetAttrStr(__pyx_v_self, __pyx_n_s_i_factors); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 278, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_1);
-      __pyx_t_3 = __Pyx_PyObject_GetItem(__pyx_t_1, __pyx_v_item_id); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 278, __pyx_L1_error)
+      __pyx_t_3 = __Pyx_PyObject_GetItem(__pyx_t_1, __pyx_v_item_idx); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 278, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_3);
       __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
       __pyx_t_1 = NULL;
@@ -17268,8 +17268,8 @@ static PyObject *__pyx_pf_6cornac_6models_3nmf_9recom_nmf_3NMF_6score(CYTHON_UNU
     __pyx_L5:;
 
     /* "cornac/models/nmf/recom_nmf.pyx":279
- *                     raise ScoreException("Can't make score prediction for (user_id=%d, item_id=%d)" % (user_id, item_id))
- *                 item_score = np.dot(self.u_factors[user_id], self.i_factors[item_id])
+ *                     raise ScoreException("Can't make score prediction for (user_id=%d, item_id=%d)" % (user_idx, item_idx))
+ *                 item_score = np.dot(self.u_factors[user_idx], self.i_factors[item_idx])
  *             return item_score             # <<<<<<<<<<<<<<
  */
     __Pyx_XDECREF(__pyx_r);
@@ -17281,7 +17281,7 @@ static PyObject *__pyx_pf_6cornac_6models_3nmf_9recom_nmf_3NMF_6score(CYTHON_UNU
   /* "cornac/models/nmf/recom_nmf.pyx":239
  * 
  * 
- *     def score(self, user_id, item_id=None):             # <<<<<<<<<<<<<<
+ *     def score(self, user_idx, item_idx=None):             # <<<<<<<<<<<<<<
  *         """Predict the scores/ratings of a user for an item.
  * 
  */
@@ -33340,8 +33340,8 @@ static __Pyx_StringTabEntry __pyx_string_tab[] = {
   {&__pyx_n_s_is_unk_item, __pyx_k_is_unk_item, sizeof(__pyx_k_is_unk_item), 0, 0, 1, 1},
   {&__pyx_n_s_is_unk_user, __pyx_k_is_unk_user, sizeof(__pyx_k_is_unk_user), 0, 0, 1, 1},
   {&__pyx_n_s_item_counts, __pyx_k_item_counts, sizeof(__pyx_k_item_counts), 0, 0, 1, 1},
-  {&__pyx_n_s_item_id, __pyx_k_item_id, sizeof(__pyx_k_item_id), 0, 0, 1, 1},
-  {&__pyx_kp_u_item_id_2, __pyx_k_item_id_2, sizeof(__pyx_k_item_id_2), 0, 1, 0, 0},
+  {&__pyx_kp_u_item_id, __pyx_k_item_id, sizeof(__pyx_k_item_id), 0, 1, 0, 0},
+  {&__pyx_n_s_item_idx, __pyx_k_item_idx, sizeof(__pyx_k_item_idx), 0, 0, 1, 1},
   {&__pyx_n_s_item_score, __pyx_k_item_score, sizeof(__pyx_k_item_score), 0, 0, 1, 1},
   {&__pyx_n_s_itemsize, __pyx_k_itemsize, sizeof(__pyx_k_itemsize), 0, 0, 1, 1},
   {&__pyx_kp_s_itemsize_0_for_cython_array, __pyx_k_itemsize_0_for_cython_array, sizeof(__pyx_k_itemsize_0_for_cython_array), 0, 0, 1, 0},
@@ -33458,8 +33458,8 @@ static __Pyx_StringTabEntry __pyx_string_tab[] = {
   {&__pyx_n_s_update, __pyx_k_update, sizeof(__pyx_k_update), 0, 0, 1, 1},
   {&__pyx_n_s_use_bias, __pyx_k_use_bias, sizeof(__pyx_k_use_bias), 0, 0, 1, 1},
   {&__pyx_n_s_user_counts, __pyx_k_user_counts, sizeof(__pyx_k_user_counts), 0, 0, 1, 1},
-  {&__pyx_n_s_user_id, __pyx_k_user_id, sizeof(__pyx_k_user_id), 0, 0, 1, 1},
   {&__pyx_n_s_user_ids, __pyx_k_user_ids, sizeof(__pyx_k_user_ids), 0, 0, 1, 1},
+  {&__pyx_n_s_user_idx, __pyx_k_user_idx, sizeof(__pyx_k_user_idx), 0, 0, 1, 1},
   {&__pyx_n_s_utils, __pyx_k_utils, sizeof(__pyx_k_utils), 0, 0, 1, 1},
   {&__pyx_n_s_utils_init_utils, __pyx_k_utils_init_utils, sizeof(__pyx_k_utils_init_utils), 0, 0, 1, 1},
   {&__pyx_n_s_val, __pyx_k_val, sizeof(__pyx_k_val), 0, 0, 1, 1},
@@ -33829,11 +33829,11 @@ static CYTHON_SMALL_CODE int __Pyx_InitCachedConstants(void) {
   /* "cornac/models/nmf/recom_nmf.pyx":239
  * 
  * 
- *     def score(self, user_id, item_id=None):             # <<<<<<<<<<<<<<
+ *     def score(self, user_idx, item_idx=None):             # <<<<<<<<<<<<<<
  *         """Predict the scores/ratings of a user for an item.
  * 
  */
-  __pyx_tuple__40 = PyTuple_Pack(7, __pyx_n_s_self, __pyx_n_s_user_id, __pyx_n_s_item_id, __pyx_n_s_unk_user, __pyx_n_s_known_item_scores, __pyx_n_s_unk_item, __pyx_n_s_item_score); if (unlikely(!__pyx_tuple__40)) __PYX_ERR(0, 239, __pyx_L1_error)
+  __pyx_tuple__40 = PyTuple_Pack(7, __pyx_n_s_self, __pyx_n_s_user_idx, __pyx_n_s_item_idx, __pyx_n_s_unk_user, __pyx_n_s_known_item_scores, __pyx_n_s_unk_item, __pyx_n_s_item_score); if (unlikely(!__pyx_tuple__40)) __PYX_ERR(0, 239, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_tuple__40);
   __Pyx_GIVEREF(__pyx_tuple__40);
   __pyx_codeobj__41 = (PyObject*)__Pyx_PyCode_New(3, 0, 7, 0, CO_OPTIMIZED|CO_NEWLOCALS, __pyx_empty_bytes, __pyx_empty_tuple, __pyx_empty_tuple, __pyx_tuple__40, __pyx_empty_tuple, __pyx_empty_tuple, __pyx_kp_s_cornac_models_nmf_recom_nmf_pyx, __pyx_n_s_score, 239, __pyx_empty_bytes); if (unlikely(!__pyx_codeobj__41)) __PYX_ERR(0, 239, __pyx_L1_error)
@@ -34461,7 +34461,7 @@ if (!__Pyx_RefNanny) {
   /* "cornac/models/nmf/recom_nmf.pyx":239
  * 
  * 
- *     def score(self, user_id, item_id=None):             # <<<<<<<<<<<<<<
+ *     def score(self, user_idx, item_idx=None):             # <<<<<<<<<<<<<<
  *         """Predict the scores/ratings of a user for an item.
  * 
  */

--- a/cornac/models/nmf/recom_nmf.pyx
+++ b/cornac/models/nmf/recom_nmf.pyx
@@ -236,15 +236,15 @@ class NMF(Recommender):
             print('Optimization finished!')
 
 
-    def score(self, user_id, item_id=None):
+    def score(self, user_idx, item_idx=None):
         """Predict the scores/ratings of a user for an item.
 
         Parameters
         ----------
-        user_id: int, required
+        user_idx: int, required
             The index of the user for whom to perform score prediction.
 
-        item_id: int, optional, default: None
+        item_idx: int, optional, default: None
             The index of the item for that to perform score prediction.
             If None, scores for all known items will be returned.
 
@@ -254,26 +254,26 @@ class NMF(Recommender):
             Relative scores that the user gives to the item or to all known items
 
         """
-        unk_user = self.train_set.is_unk_user(user_id)
+        unk_user = self.train_set.is_unk_user(user_idx)
 
-        if item_id is None:
+        if item_idx is None:
             known_item_scores = np.add(self.i_biases, self.global_mean)
             if not unk_user:
-                known_item_scores = np.add(known_item_scores, self.u_biases[user_id])
-                fast_dot(self.u_factors[user_id], self.i_factors, known_item_scores)
+                known_item_scores = np.add(known_item_scores, self.u_biases[user_idx])
+                fast_dot(self.u_factors[user_idx], self.i_factors, known_item_scores)
             return known_item_scores
         else:
-            unk_item = self.train_set.is_unk_item(item_id)
+            unk_item = self.train_set.is_unk_item(item_idx)
             if self.use_bias:
                 item_score = self.global_mean
                 if not unk_user:
-                    item_score += self.u_biases[user_id]
+                    item_score += self.u_biases[user_idx]
                 if not unk_item:
-                    item_score += self.i_biases[item_id]
+                    item_score += self.i_biases[item_idx]
                 if not unk_user and not unk_item:
-                    item_score += np.dot(self.u_factors[user_id], self.i_factors[item_id])
+                    item_score += np.dot(self.u_factors[user_idx], self.i_factors[item_idx])
             else:
                 if unk_user or unk_item:
-                    raise ScoreException("Can't make score prediction for (user_id=%d, item_id=%d)" % (user_id, item_id))
-                item_score = np.dot(self.u_factors[user_id], self.i_factors[item_id])
+                    raise ScoreException("Can't make score prediction for (user_id=%d, item_id=%d)" % (user_idx, item_idx))
+                item_score = np.dot(self.u_factors[user_idx], self.i_factors[item_idx])
             return item_score

--- a/cornac/models/nmf/recom_nmf.pyx
+++ b/cornac/models/nmf/recom_nmf.pyx
@@ -113,10 +113,10 @@ class NMF(Recommender):
 
         Parameters
         ----------
-        train_set: :obj:`cornac.data.MultimodalTrainSet`, required
+        train_set: :obj:`cornac.data.Dataset`, required
             User-Item preference data as well as additional modalities.
 
-        val_set: :obj:`cornac.data.MultimodalTestSet`, optional, default: None
+        val_set: :obj:`cornac.data.Dataset`, optional, default: None
             User-Item preference data for model selection purposes (e.g., early stopping).
 
         Returns

--- a/cornac/models/online_ibpr/recom_online_ibpr.py
+++ b/cornac/models/online_ibpr/recom_online_ibpr.py
@@ -85,10 +85,10 @@ class OnlineIBPR(Recommender):
 
         Parameters
         ----------
-        train_set: :obj:`cornac.data.MultimodalTrainSet`, required
+        train_set: :obj:`cornac.data.Dataset`, required
             User-Item preference data as well as additional modalities.
 
-        val_set: :obj:`cornac.data.MultimodalTestSet`, optional, default: None
+        val_set: :obj:`cornac.data.Dataset`, optional, default: None
             User-Item preference data for model selection purposes (e.g., early stopping).
 
         Returns

--- a/cornac/models/online_ibpr/recom_online_ibpr.py
+++ b/cornac/models/online_ibpr/recom_online_ibpr.py
@@ -118,15 +118,15 @@ class OnlineIBPR(Recommender):
 
         return self
 
-    def score(self, user_id, item_id=None):
+    def score(self, user_idx, item_idx=None):
         """Predict the scores/ratings of a user for an item.
 
         Parameters
         ----------
-        user_id: int, required
+        user_idx: int, required
             The index of the user for whom to perform score prediction.
 
-        item_id: int, optional, default: None
+        item_idx: int, optional, default: None
             The index of the item for that to perform score prediction.
             If None, scores for all known items will be returned.
 
@@ -136,15 +136,15 @@ class OnlineIBPR(Recommender):
             Relative scores that the user gives to the item or to all known items
 
         """
-        if item_id is None:
-            if self.train_set.is_unk_user(user_id):
-                raise ScoreException("Can't make score prediction for (user_id=%d)" % user_id)
+        if item_idx is None:
+            if self.train_set.is_unk_user(user_idx):
+                raise ScoreException("Can't make score prediction for (user_id=%d)" % user_idx)
 
-            known_item_scores = self.V.dot(self.U[user_id, :])
+            known_item_scores = self.V.dot(self.U[user_idx, :])
             return known_item_scores
         else:
-            if self.train_set.is_unk_user(user_id) or self.train_set.is_unk_item(item_id):
-                raise ScoreException("Can't make score prediction for (user_id=%d, item_id=%d)" % (user_id, item_id))
+            if self.train_set.is_unk_user(user_idx) or self.train_set.is_unk_item(item_idx):
+                raise ScoreException("Can't make score prediction for (user_id=%d, item_id=%d)" % (user_idx, item_idx))
 
-            user_pred = self.V[item_id, :].dot(self.U[user_id, :])
+            user_pred = self.V[item_idx, :].dot(self.U[user_idx, :])
             return user_pred

--- a/cornac/models/pcrl/recom_pcrl.py
+++ b/cornac/models/pcrl/recom_pcrl.py
@@ -122,15 +122,15 @@ class PCRL(Recommender):
 
         return self
 
-    def score(self, user_id, item_id=None):
+    def score(self, user_idx, item_idx=None):
         """Predict the scores/ratings of a user for a list of items.
 
         Parameters
         ----------
-        user_id: int, required
+        user_idx: int, required
             The index of the user for whom to perform score prediction.
 
-        item_id: int, optional, default: None
+        item_idx: int, optional, default: None
             The index of the item for that to perform score prediction.
             If None, scores for all known items will be returned.
 
@@ -141,10 +141,10 @@ class PCRL(Recommender):
 
         """
 
-        if item_id is None:
-            user_pred = self.Beta * self.Theta[user_id, :].T
+        if item_idx is None:
+            user_pred = self.Beta * self.Theta[user_idx, :].T
         else:
-            user_pred = self.Beta[item_id, :] * self.Theta[user_id, :].T
+            user_pred = self.Beta[item_idx, :] * self.Theta[user_idx, :].T
         # transform user_pred to a flatten array
         user_pred = np.array(user_pred, dtype='float64').flatten()
 

--- a/cornac/models/pcrl/recom_pcrl.py
+++ b/cornac/models/pcrl/recom_pcrl.py
@@ -92,10 +92,10 @@ class PCRL(Recommender):
 
         Parameters
         ----------
-        train_set: :obj:`cornac.data.MultimodalTrainSet`, required
+        train_set: :obj:`cornac.data.Dataset`, required
             User-Item preference data as well as additional modalities.
 
-        val_set: :obj:`cornac.data.MultimodalTestSet`, optional, default: None
+        val_set: :obj:`cornac.data.Dataset`, optional, default: None
             User-Item preference data for model selection purposes (e.g., early stopping).
 
         Returns

--- a/cornac/models/pmf/recom_pmf.py
+++ b/cornac/models/pmf/recom_pmf.py
@@ -141,15 +141,15 @@ class PMF(Recommender):
 
         return self
 
-    def score(self, user_id, item_id=None):
+    def score(self, user_idx, item_idx=None):
         """Predict the scores/ratings of a user for an item.
 
         Parameters
         ----------
-        user_id: int, required
+        user_idx: int, required
             The index of the user for whom to perform score prediction.
 
-        item_id: int, optional, default: None
+        item_idx: int, optional, default: None
             The index of the item for that to perform score prediction.
             If None, scores for all known items will be returned.
 
@@ -159,17 +159,17 @@ class PMF(Recommender):
             Relative scores that the user gives to the item or to all known items
 
         """
-        if item_id is None:
-            if self.train_set.is_unk_user(user_id):
-                raise ScoreException("Can't make score prediction for (user_id=%d)" % user_id)
+        if item_idx is None:
+            if self.train_set.is_unk_user(user_idx):
+                raise ScoreException("Can't make score prediction for (user_id=%d)" % user_idx)
 
-            known_item_scores = self.V.dot(self.U[user_id, :])
+            known_item_scores = self.V.dot(self.U[user_idx, :])
             return known_item_scores
         else:
-            if self.train_set.is_unk_user(user_id) or self.train_set.is_unk_item(item_id):
-                raise ScoreException("Can't make score prediction for (user_id=%d, item_id=%d)" % (user_id, item_id))
+            if self.train_set.is_unk_user(user_idx) or self.train_set.is_unk_item(item_idx):
+                raise ScoreException("Can't make score prediction for (user_id=%d, item_id=%d)" % (user_idx, item_idx))
 
-            user_pred = self.V[item_id, :].dot(self.U[user_id, :])
+            user_pred = self.V[item_idx, :].dot(self.U[user_idx, :])
 
             if self.variant == "non_linear":
                 user_pred = sigmoid(user_pred)

--- a/cornac/models/pmf/recom_pmf.py
+++ b/cornac/models/pmf/recom_pmf.py
@@ -91,10 +91,10 @@ class PMF(Recommender):
 
         Parameters
         ----------
-        train_set: :obj:`cornac.data.MultimodalTrainSet`, required
+        train_set: :obj:`cornac.data.Dataset`, required
             User-Item preference data as well as additional modalities.
 
-        val_set: :obj:`cornac.data.MultimodalTestSet`, optional, default: None
+        val_set: :obj:`cornac.data.Dataset`, optional, default: None
             User-Item preference data for model selection purposes (e.g., early stopping).
 
         Returns

--- a/cornac/models/recommender.py
+++ b/cornac/models/recommender.py
@@ -93,28 +93,6 @@ class Recommender:
         """
         return self.train_set.global_mean
 
-    def default_rank(self, item_ids=None):
-        """Overwrite this function if your algorithm has special treatment for cold-start problem
-
-        """
-        known_item_rank = self.train_set.item_ppl_rank
-        known_item_scores = self.train_set.item_ppl_scores
-
-        if item_ids is None:
-            item_rank = known_item_rank
-            item_scores = known_item_scores
-        else:
-            known_item_ids = intersects(known_item_rank, item_ids, assume_unique=True)
-            unk_item_ids = excepts(known_item_rank, item_ids, assume_unique=True)
-            item_rank = np.concatenate((known_item_ids, unk_item_ids))
-
-            num_items = max(self.train_set.num_items, max(item_ids) + 1)
-            item_scores = np.ones(num_items) * np.min(known_item_scores)
-            item_scores[:self.train_set.num_items] = known_item_scores
-            item_scores = item_scores[item_ids]
-
-        return item_rank, item_scores
-
     def rate(self, user_id, item_id, clipping=True):
         """Give a rating score between pair of user and item
 

--- a/cornac/models/recommender.py
+++ b/cornac/models/recommender.py
@@ -67,15 +67,15 @@ class Recommender:
         self.val_set = val_set
         return self
 
-    def score(self, user_id, item_id=None):
+    def score(self, user_idx, item_idx=None):
         """Predict the scores/ratings of a user for an item.
 
         Parameters
         ----------
-        user_id: int, required
+        user_idx: int, required
             The index of the user for whom to perform score prediction.
             
-        item_id: int, optional, default: None
+        item_idx: int, optional, default: None
             The index of the item for that to perform score prediction.
             If None, scores for all known items will be returned.
 
@@ -93,15 +93,15 @@ class Recommender:
         """
         return self.train_set.global_mean
 
-    def rate(self, user_id, item_id, clipping=True):
+    def rate(self, user_idx, item_idx, clipping=True):
         """Give a rating score between pair of user and item
 
         Parameters
         ----------
-        user_id: int, required
+        user_idx: int, required
             The index of the user for whom to perform item raking.
 
-        item_id: int, required
+        item_idx: int, required
             The index of the item to be rated by the user.
 
         clipping: bool, default: True
@@ -113,7 +113,7 @@ class Recommender:
             A rating score of the user for the item
         """
         try:
-            rating_pred = self.score(user_id, item_id)
+            rating_pred = self.score(user_idx, item_idx)
         except ScoreException:
             rating_pred = self.default_score()
 
@@ -124,15 +124,15 @@ class Recommender:
 
         return rating_pred
 
-    def rank(self, user_id, item_ids=None):
+    def rank(self, user_idx, item_indices=None):
         """Rank all test items for a given user.
 
         Parameters
         ----------
-        user_id: int, required
+        user_idx: int, required
             The index of the user for whom to perform item raking.
 
-        item_ids: 1d array, optional, default: None
+        item_indices: 1d array, optional, default: None
             A list of candidate item indices to be ranked by the user.
             If `None`, list of ranked known item indices and their scores will be returned
 
@@ -143,20 +143,20 @@ class Recommender:
 
         """
         try:
-            known_item_scores = self.score(user_id)
+            known_item_scores = self.score(user_idx)
         except ScoreException:
             known_item_scores = np.ones(self.train_set.num_items) * self.default_score()
 
-        if item_ids is None:
+        if item_indices is None:
             item_scores = known_item_scores
             item_rank = item_scores.argsort()[::-1]
         else:
-            num_items = max(self.train_set.num_items, max(item_ids) + 1)
+            num_items = max(self.train_set.num_items, max(item_indices) + 1)
             item_scores = np.ones(num_items) * np.min(known_item_scores)
             item_scores[:self.train_set.num_items] = known_item_scores
             item_rank = item_scores.argsort()[::-1]
-            item_rank = intersects(item_rank, item_ids, assume_unique=True)
-            item_scores = item_scores[item_ids]
+            item_rank = intersects(item_rank, item_indices, assume_unique=True)
+            item_scores = item_scores[item_indices]
         return item_rank, item_scores
 
     def val_loss(self):

--- a/cornac/models/sbpr/recom_sbpr.cpp
+++ b/cornac/models/sbpr/recom_sbpr.cpp
@@ -3750,7 +3750,7 @@ static PyObject *__pyx_pf_6cornac_6models_4sbpr_10recom_sbpr_4SBPR___init__(CYTH
 
 /* Python wrapper */
 static PyObject *__pyx_pw_6cornac_6models_4sbpr_10recom_sbpr_4SBPR_3fit(PyObject *__pyx_self, PyObject *__pyx_args, PyObject *__pyx_kwds); /*proto*/
-static char __pyx_doc_6cornac_6models_4sbpr_10recom_sbpr_4SBPR_2fit[] = "Fit the model to observations.\n\n        Parameters\n        ----------\n        train_set: :obj:`cornac.data.MultimodalTrainSet`, required\n            User-Item preference data as well as additional modalities.\n\n        val_set: :obj:`cornac.data.MultimodalTestSet`, optional, default: None\n            User-Item preference data for model selection purposes (e.g., early stopping).\n\n        Returns\n        -------\n        self : object\n        ";
+static char __pyx_doc_6cornac_6models_4sbpr_10recom_sbpr_4SBPR_2fit[] = "Fit the model to observations.\n\n        Parameters\n        ----------\n        train_set: :obj:`cornac.data.Dataset`, required\n            User-Item preference data as well as additional modalities.\n\n        val_set: :obj:`cornac.data.Dataset`, optional, default: None\n            User-Item preference data for model selection purposes (e.g., early stopping).\n\n        Returns\n        -------\n        self : object\n        ";
 static PyMethodDef __pyx_mdef_6cornac_6models_4sbpr_10recom_sbpr_4SBPR_3fit = {"fit", (PyCFunction)(void*)(PyCFunctionWithKeywords)__pyx_pw_6cornac_6models_4sbpr_10recom_sbpr_4SBPR_3fit, METH_VARARGS|METH_KEYWORDS, __pyx_doc_6cornac_6models_4sbpr_10recom_sbpr_4SBPR_2fit};
 static PyObject *__pyx_pw_6cornac_6models_4sbpr_10recom_sbpr_4SBPR_3fit(PyObject *__pyx_self, PyObject *__pyx_args, PyObject *__pyx_kwds) {
   PyObject *__pyx_v_self = 0;

--- a/cornac/models/sbpr/recom_sbpr.pyx
+++ b/cornac/models/sbpr/recom_sbpr.pyx
@@ -101,10 +101,10 @@ class SBPR(Recommender):
 
         Parameters
         ----------
-        train_set: :obj:`cornac.data.MultimodalTrainSet`, required
+        train_set: :obj:`cornac.data.Dataset`, required
             User-Item preference data as well as additional modalities.
 
-        val_set: :obj:`cornac.data.MultimodalTestSet`, optional, default: None
+        val_set: :obj:`cornac.data.Dataset`, optional, default: None
             User-Item preference data for model selection purposes (e.g., early stopping).
 
         Returns

--- a/cornac/models/sbpr/recom_sbpr.pyx
+++ b/cornac/models/sbpr/recom_sbpr.pyx
@@ -277,15 +277,15 @@ class SBPR(Recommender):
 
         return skipped
 
-    def score(self, user_id, item_id=None):
+    def score(self, user_idx, item_idx=None):
         """Predict the scores/ratings of a user for an item.
 
         Parameters
         ----------
-        user_id: int, required
+        user_idx: int, required
             The index of the user for whom to perform score prediction.
 
-        item_id: int, optional, default: None
+        item_idx: int, optional, default: None
             The index of the item for that to perform score prediction.
             If None, scores for all known items will be returned.
 
@@ -295,19 +295,19 @@ class SBPR(Recommender):
             Relative scores that the user gives to the item or to all known items
 
         """
-        unk_user = self.train_set.is_unk_user(user_id)
+        unk_user = self.train_set.is_unk_user(user_idx)
 
-        if item_id is None:
+        if item_idx is None:
             known_item_scores = np.copy(self.i_biases)
             if not unk_user:
-                fast_dot(self.u_factors[user_id], self.i_factors, known_item_scores)
+                fast_dot(self.u_factors[user_idx], self.i_factors, known_item_scores)
             return known_item_scores
         else:
-            if self.train_set.is_unk_item(item_id):
-                raise ScoreException("Can't make score prediction for (user_id=%d, item_id=%d)" % (user_id, item_id))
-            item_score = self.i_biases[item_id]
+            if self.train_set.is_unk_item(item_idx):
+                raise ScoreException("Can't make score prediction for (user_id=%d, item_id=%d)" % (user_idx, item_idx))
+            item_score = self.i_biases[item_idx]
             if not unk_user:
-                item_score += np.dot(self.u_factors[user_id], self.i_factors[item_id])
+                item_score += np.dot(self.u_factors[user_idx], self.i_factors[item_idx])
             if self.train_set.min_rating != self.train_set.max_rating:
                 item_score = scale(item_score, self.train_set.min_rating, self.train_set.max_rating, 0., 1.)
             return item_score

--- a/cornac/models/skm/recom_skmeans.py
+++ b/cornac/models/skm/recom_skmeans.py
@@ -71,10 +71,10 @@ class SKMeans(Recommender):
 
         Parameters
         ----------
-        train_set: :obj:`cornac.data.MultimodalTrainSet`, required
+        train_set: :obj:`cornac.data.Dataset`, required
             User-Item preference data as well as additional modalities.
 
-        val_set: :obj:`cornac.data.MultimodalTestSet`, optional, default: None
+        val_set: :obj:`cornac.data.Dataset`, optional, default: None
             User-Item preference data for model selection purposes (e.g., early stopping).
 
         Returns

--- a/cornac/models/skm/recom_skmeans.py
+++ b/cornac/models/skm/recom_skmeans.py
@@ -104,15 +104,15 @@ class SKMeans(Recommender):
 
         return self
 
-    def score(self, user_id, item_id=None):
+    def score(self, user_idx, item_idx=None):
         """Predict the scores/ratings of a user for an item.
 
         Parameters
         ----------
-        user_id: int, required
+        user_idx: int, required
             The index of the user for whom to perform score prediction.
 
-        item_id: int, optional, default: None
+        item_idx: int, optional, default: None
             The index of the item for that to perform score prediction.
             If None, scores for all known items will be returned.
 
@@ -122,21 +122,21 @@ class SKMeans(Recommender):
             Relative scores that the user gives to the item or to all known items
 
         """
-        if item_id is None:
-            if self.train_set.is_unk_user(user_id):
-                raise ScoreException("Can't make score prediction for (user_id=%d)" % user_id)
+        if item_idx is None:
+            if self.train_set.is_unk_user(user_idx):
+                raise ScoreException("Can't make score prediction for (user_id=%d)" % user_idx)
 
-            known_item_scores = self.centroids.multiply(self.user_center_sim[user_id, :].T)
+            known_item_scores = self.centroids.multiply(self.user_center_sim[user_idx, :].T)
             known_item_scores = known_item_scores.sum(0).A1 / (
-                    self.user_center_sim[user_id, :].sum() + 1e-20)  # weighted average of cluster centroids
+                    self.user_center_sim[user_idx, :].sum() + 1e-20)  # weighted average of cluster centroids
             return known_item_scores
         else:
-            if self.train_set.is_unk_user(user_id) or self.train_set.is_unk_item(item_id):
-                raise ScoreException("Can't make score prediction for (user_id=%d, item_id=%d)" % (user_id, item_id))
+            if self.train_set.is_unk_user(user_idx) or self.train_set.is_unk_item(item_idx):
+                raise ScoreException("Can't make score prediction for (user_id=%d, item_id=%d)" % (user_idx, item_idx))
 
-            user_pred = self.centroids[item_id, :].multiply(self.user_center_sim[user_id, :].T)
+            user_pred = self.centroids[item_idx, :].multiply(self.user_center_sim[user_idx, :].T)
             # transform user_pred to a flatten array
             user_pred = user_pred.sum(0).A1 / (
-                    self.user_center_sim[user_id, :].sum() + 1e-20)  # weighted average of cluster centroids
+                    self.user_center_sim[user_idx, :].sum() + 1e-20)  # weighted average of cluster centroids
 
             return user_pred

--- a/cornac/models/sorec/recom_sorec.py
+++ b/cornac/models/sorec/recom_sorec.py
@@ -104,10 +104,10 @@ class SoRec(Recommender):
 
         Parameters
         ----------
-        train_set: :obj:`cornac.data.MultimodalTrainSet`, required
+        train_set: :obj:`cornac.data.Dataset`, required
             User-Item preference data as well as additional modalities.
 
-        val_set: :obj:`cornac.data.MultimodalTestSet`, optional, default: None
+        val_set: :obj:`cornac.data.Dataset`, optional, default: None
             User-Item preference data for model selection purposes (e.g., early stopping).
 
         Returns

--- a/cornac/models/sorec/recom_sorec.py
+++ b/cornac/models/sorec/recom_sorec.py
@@ -174,13 +174,13 @@ class SoRec(Recommender):
 
         return self
 
-    def score(self, user_id, item_id=None):
+    def score(self, user_idx, item_idx=None):
         """Predict the scores/ratings of a user for an item.
         Parameters
         ----------
-        user_id: int, required
+        user_idx: int, required
             The index of the user for whom to perform score prediction.
-        item_id: int, optional, default: None
+        item_idx: int, optional, default: None
             The index of the item for that to perform score prediction.
             If None, scores for all known items will be returned.
         Returns
@@ -188,17 +188,17 @@ class SoRec(Recommender):
         res : A scalar or a Numpy array
             Relative scores that the user gives to the item or to all known items
         """
-        if item_id is None:
-            if self.train_set.is_unk_user(user_id):
-                raise ScoreException("Can't make score prediction for (user_id=%d)" % user_id)
+        if item_idx is None:
+            if self.train_set.is_unk_user(user_idx):
+                raise ScoreException("Can't make score prediction for (user_id=%d)" % user_idx)
 
-            known_item_scores = self.V.dot(self.U[user_id, :])
+            known_item_scores = self.V.dot(self.U[user_idx, :])
             return known_item_scores
         else:
-            if self.train_set.is_unk_user(user_id) or self.train_set.is_unk_item(item_id):
-                raise ScoreException("Can't make score prediction for (user_id=%d, item_id=%d)" % (user_id, item_id))
+            if self.train_set.is_unk_user(user_idx) or self.train_set.is_unk_item(item_idx):
+                raise ScoreException("Can't make score prediction for (user_id=%d, item_id=%d)" % (user_idx, item_idx))
 
-            user_pred = self.V[item_id, :].dot(self.U[user_id, :])
+            user_pred = self.V[item_idx, :].dot(self.U[user_idx, :])
             user_pred = sigmoid(user_pred)
             if self.train_set.min_rating == self.train_set.max_rating:
                 user_pred = scale(user_pred, 0., self.train_set.max_rating, 0., 1.)

--- a/cornac/models/vaecf/recom_vaecf.py
+++ b/cornac/models/vaecf/recom_vaecf.py
@@ -110,15 +110,15 @@ class VAECF(Recommender):
 
         return self
 
-    def score(self, user_id, item_id=None):
+    def score(self, user_idx, item_idx=None):
         """Predict the scores/ratings of a user for an item.
 
         Parameters
         ----------
-        user_id: int, required
+        user_idx: int, required
             The index of the user for whom to perform score prediction.
 
-        item_id: int, optional, default: None
+        item_idx: int, optional, default: None
             The index of the item for that to perform score prediction.
             If None, scores for all known items will be returned.
 
@@ -129,20 +129,20 @@ class VAECF(Recommender):
 
         """
         import torch
-        if item_id is None:
-            if self.train_set.is_unk_user(user_id):
-                raise ScoreException("Can't make score prediction for (user_id=%d)" % user_id)
-            x_u = self.train_set.matrix[user_id].copy()
+        if item_idx is None:
+            if self.train_set.is_unk_user(user_idx):
+                raise ScoreException("Can't make score prediction for (user_id=%d)" % user_idx)
+            x_u = self.train_set.matrix[user_idx].copy()
             x_u.data = np.ones(len(x_u.data))
             z_u, _ = self.vae.encode(torch.tensor(x_u.A, dtype=torch.double))
             known_item_scores = self.vae.decode(z_u).data.cpu().numpy().flatten()
             return known_item_scores
         else:
-            if self.train_set.is_unk_user(user_id) or self.train_set.is_unk_item(item_id):
-                raise ScoreException("Can't make score prediction for (user_id=%d, item_id=%d)" % (user_id, item_id))
-            x_u = self.train_set.matrix[user_id].copy()
+            if self.train_set.is_unk_user(user_idx) or self.train_set.is_unk_item(item_idx):
+                raise ScoreException("Can't make score prediction for (user_id=%d, item_id=%d)" % (user_idx, item_idx))
+            x_u = self.train_set.matrix[user_idx].copy()
             x_u.data = np.ones(len(x_u.data))
             z_u, _ = self.vae.encode(torch.tensor(x_u.A, dtype=torch.double))
-            user_pred = self.vae.decode(z_u).data.cpu().numpy().flatten()[item_id]  # Fix me I am not efficient
+            user_pred = self.vae.decode(z_u).data.cpu().numpy().flatten()[item_idx]  # Fix me I am not efficient
 
             return user_pred

--- a/cornac/models/vaecf/recom_vaecf.py
+++ b/cornac/models/vaecf/recom_vaecf.py
@@ -78,10 +78,10 @@ class VAECF(Recommender):
 
         Parameters
         ----------
-        train_set: :obj:`cornac.data.MultimodalTrainSet`, required
+        train_set: :obj:`cornac.data.Dataset`, required
             User-Item preference data as well as additional modalities.
 
-        val_set: :obj:`cornac.data.MultimodalTestSet`, optional, default: None
+        val_set: :obj:`cornac.data.Dataset`, optional, default: None
             User-Item preference data for model selection purposes (e.g., early stopping).
 
         Returns

--- a/cornac/models/vbpr/recom_vbpr.py
+++ b/cornac/models/vbpr/recom_vbpr.py
@@ -220,15 +220,15 @@ class VBPR(Recommender):
         self.theta_item = F.mm(E).data.cpu().numpy()
         self.visual_bias = F.mm(Bp).data.cpu().numpy().ravel()
 
-    def score(self, user_id, item_id=None):
+    def score(self, user_idx, item_idx=None):
         """Predict the scores/ratings of a user for an item.
 
         Parameters
         ----------
-        user_id: int, required
+        user_idx: int, required
             The index of the user for whom to perform score prediction.
 
-        item_id: int, optional, default: None
+        item_idx: int, optional, default: None
             The index of the item for that to perform score prediction.
             If None, scores for all known items will be returned.
 
@@ -238,18 +238,18 @@ class VBPR(Recommender):
             Relative scores that the user gives to the item or to all known items
 
         """
-        if item_id is None:
+        if item_idx is None:
             known_item_scores = np.add(self.beta_item, self.visual_bias)
-            if not self.train_set.is_unk_user(user_id):
-                fast_dot(self.gamma_user[user_id], self.gamma_item, known_item_scores)
-                fast_dot(self.theta_user[user_id], self.theta_item, known_item_scores)
+            if not self.train_set.is_unk_user(user_idx):
+                fast_dot(self.gamma_user[user_idx], self.gamma_item, known_item_scores)
+                fast_dot(self.theta_user[user_idx], self.theta_item, known_item_scores)
             return known_item_scores
         else:
-            if self.train_set.is_unk_item(item_id):
-                raise ScoreException("Can't make score prediction for (item_id=%d)" % item_id)
+            if self.train_set.is_unk_item(item_idx):
+                raise ScoreException("Can't make score prediction for (item_id=%d)" % item_idx)
 
-            item_score = np.add(self.beta_item[item_id], self.visual_bias[item_id])
-            if not self.train_set.is_unk_user(user_id):
-                item_score += np.dot(self.gamma_item[item_id], self.gamma_user[user_id])
-                item_score += np.dot(self.theta_item[item_id], self.theta_user[user_id])
+            item_score = np.add(self.beta_item[item_idx], self.visual_bias[item_idx])
+            if not self.train_set.is_unk_user(user_idx):
+                item_score += np.dot(self.gamma_item[item_idx], self.gamma_user[user_idx])
+                item_score += np.dot(self.theta_item[item_idx], self.theta_user[user_idx])
             return item_score

--- a/cornac/models/vbpr/recom_vbpr.py
+++ b/cornac/models/vbpr/recom_vbpr.py
@@ -110,10 +110,10 @@ class VBPR(Recommender):
 
         Parameters
         ----------
-        train_set: :obj:`cornac.data.MultimodalTrainSet`, required
+        train_set: :obj:`cornac.data.Dataset`, required
             User-Item preference data as well as additional modalities.
 
-        val_set: :obj:`cornac.data.MultimodalTestSet`, optional, default: None
+        val_set: :obj:`cornac.data.Dataset`, optional, default: None
             User-Item preference data for model selection purposes (e.g., early stopping).
 
         Returns

--- a/cornac/models/vmf/recom_vmf.py
+++ b/cornac/models/vmf/recom_vmf.py
@@ -156,15 +156,15 @@ class VMF(Recommender):
 
         return self
 
-    def score(self, user_id, item_id=None):
+    def score(self, user_idx, item_idx=None):
         """Predict the scores/ratings of a user for an item.
 
         Parameters
         ----------
-        user_id: int, required
+        user_idx: int, required
             The index of the user for whom to perform score prediction.
 
-        item_id: int, optional, default: None
+        item_idx: int, optional, default: None
             The index of the item for that to perform score prediction.
             If None, scores for all known items will be returned.
 
@@ -174,19 +174,19 @@ class VMF(Recommender):
             Relative scores that the user gives to the item or to all known items
 
         """
-        if item_id is None:
-            if self.train_set.is_unk_user(user_id):
-                raise ScoreException("Can't make score prediction for (user_id=%d)" % user_id)
+        if item_idx is None:
+            if self.train_set.is_unk_user(user_idx):
+                raise ScoreException("Can't make score prediction for (user_id=%d)" % user_idx)
 
-            known_item_scores = self.V.dot(self.U[user_id, :]) + self.Q.dot(self.P[user_id, :])
+            known_item_scores = self.V.dot(self.U[user_idx, :]) + self.Q.dot(self.P[user_idx, :])
             # known_item_scores = np.asarray(np.zeros(self.V.shape[0]),dtype='float32')
             # fast_dot(self.U[user_id], self.V, known_item_scores)
             # fast_dot(self.P[user_id], self.Q, known_item_scores)
             return known_item_scores
         else:
-            if self.train_set.is_unk_user(user_id) or self.train_set.is_unk_item(item_id):
-                raise ScoreException("Can't make score prediction for (user_id=%d, item_id=%d)" % (user_id, item_id))
-            user_pred = self.V[item_id, :].dot(self.U[user_id, :]) + self.Q[item_id, :].dot(self.P[user_id, :])
+            if self.train_set.is_unk_user(user_idx) or self.train_set.is_unk_item(item_idx):
+                raise ScoreException("Can't make score prediction for (user_id=%d, item_id=%d)" % (user_idx, item_idx))
+            user_pred = self.V[item_idx, :].dot(self.U[user_idx, :]) + self.Q[item_idx, :].dot(self.P[user_idx, :])
             user_pred = sigmoid(user_pred)
 
             user_pred = scale(user_pred, self.train_set.min_rating, self.train_set.max_rating, 0., 1.)

--- a/cornac/models/vmf/recom_vmf.py
+++ b/cornac/models/vmf/recom_vmf.py
@@ -115,10 +115,10 @@ class VMF(Recommender):
 
         Parameters
         ----------
-        train_set: :obj:`cornac.data.MultimodalTrainSet`, required
+        train_set: :obj:`cornac.data.Dataset`, required
             User-Item preference data as well as additional modalities.
 
-        val_set: :obj:`cornac.data.MultimodalTestSet`, optional, default: None
+        val_set: :obj:`cornac.data.Dataset`, optional, default: None
             User-Item preference data for model selection purposes (e.g., early stopping).
 
         Returns


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
To avoid confusion when dealing with user/item `raw identity` and `mapped index`:
- Orignal user/item names from raw input data should be called `identity` or `id` for short.
- After mapping/indexing, user/item will have their integer `index` or `idx` for short. Those indices will be used internally among the APIs.
- Each `Dataset` object will hold their own mapping from user/item `identity` to `index` via `uid_map` and `iid_map`.

### Related Issues
<!--- If it fixes an open issue, please link to the issue here. -->


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have added tests.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated `README.md` (if you are adding a new model).
- [ ] I have updated `examples/README.md` (if you are adding a new example).
