### PR TITLE
Sorting UIRT data chronologically for preserving order of purchased sequences

### DIFF
--- a/cornac/data/dataset.py
+++ b/cornac/data/dataset.py
@@ -234,12 +234,13 @@ class Dataset(object):
         max_rating = float('-inf')
         min_rating = float('inf')
 
-        for uid, iid, rating in itertools.filterfalse(
+        for tup in itertools.filterfalse(
                 lambda x: (x[0], x[1]) in ui_set or
                           (exclude_unknowns and (x[0] not in global_uid_map or
                                                  x[1] not in global_iid_map)),
                 data
         ):
+            uid, iid, rating = tup[0], tup[1], tup[2]
             ui_set.add((uid, iid))
             uid_map[uid] = global_uid_map.setdefault(uid, len(global_uid_map))
             iid_map[iid] = global_iid_map.setdefault(iid, len(global_iid_map))

--- a/cornac/data/reader.py
+++ b/cornac/data/reader.py
@@ -63,6 +63,10 @@ def uir_parser(tokens, **kwargs):
     return [(tokens[0], tokens[1], float(tokens[2]))]
 
 
+def uirt_parser(tokens, **kwargs):
+    return [(tokens[0], tokens[1], float(tokens[2]), float(tokens[3]))]
+
+
 def tup_parser(tokens, **kwargs):
     return [(tokens[0], tokens[1], [tuple(tup.split(kwargs.get('tup_sep'))) for tup in tokens[2:]])]
 
@@ -70,6 +74,7 @@ def tup_parser(tokens, **kwargs):
 PARSERS = {
     'UI': ui_parser,
     'UIR': uir_parser,
+    'UIRT': uirt_parser,
     'UITup': tup_parser,
 }
 

--- a/cornac/eval_methods/base_method.py
+++ b/cornac/eval_methods/base_method.py
@@ -497,6 +497,8 @@ class BaseMethod:
 
         fmt: str, default: 'UIR'
             The format of given data.
+            If `fmt` is 'UIRT', data will be sorted chronologically \
+            before constructing dataset to preserve the purchased sequences.
 
         rating_threshold: float, default: 1.0
             Threshold to decide positive or negative preferences.

--- a/cornac/eval_methods/base_method.py
+++ b/cornac/eval_methods/base_method.py
@@ -28,6 +28,7 @@ from ..data import Dataset
 from ..metrics import RatingMetric
 from ..metrics import RankingMetric
 from ..experiment.result import Result
+from ..utils.common import safe_indexing
 
 
 def rating_eval(model, metrics, test_set, user_based=False):
@@ -479,7 +480,7 @@ class BaseMethod:
         return Result(model.name, metric_avg_results, metric_user_results)
 
     @classmethod
-    def from_splits(cls, train_data, test_data, val_data=None, rating_threshold=1.0,
+    def from_splits(cls, train_data, test_data, val_data=None, fmt='UIR', rating_threshold=1.0,
                     exclude_unknowns=False, seed=None, verbose=False, **kwargs):
         """Constructing evaluation method given data.
 
@@ -493,6 +494,9 @@ class BaseMethod:
 
         val_data: array-like
             Validation data
+
+        fmt: str, default: 'UIR'
+            The format of given data.
 
         rating_threshold: float, default: 1.0
             Threshold to decide positive or negative preferences.
@@ -517,6 +521,12 @@ class BaseMethod:
                      seed=seed,
                      verbose=verbose,
                      **kwargs)
+
+        if fmt == 'UIRT':
+            train_data = safe_indexing(train_data, np.argsort([x[3] for x in train_data]))
+            test_data = safe_indexing(test_data, np.argsort([x[3] for x in test_data]))
+            if val_data is not None:
+                val_data = safe_indexing(val_data, np.argsort([x[3] for x in val_data]))
 
         return method.build(train_data=train_data,
                             test_data=test_data,

--- a/tests/cornac/data/test_reader.py
+++ b/tests/cornac/data/test_reader.py
@@ -48,6 +48,16 @@ class TestReader(unittest.TestCase):
         self.assertEqual(triplet_data[6][1], '478')
         self.assertEqual(triplet_data[8][0], '543')
 
+    def test_read_uirt(self):
+        data = self.reader.read(self.data_file, fmt='UIRT')
+
+        self.assertEqual(len(data), 10)
+        self.assertEqual(data[4][3], 891656347)
+        self.assertEqual(data[4][2], 3)
+        self.assertEqual(data[4][1], '705')
+        self.assertEqual(data[4][0], '329')
+        self.assertEqual(data[9][3], 879451804)
+
     def test_read_tup(self):
         tup_data = self.reader.read(self.data_file, fmt='UITup')
         self.assertEqual(len(tup_data), 10)

--- a/tests/cornac/eval_methods/test_base_method.py
+++ b/tests/cornac/eval_methods/test_base_method.py
@@ -45,7 +45,7 @@ class TestBaseMethod(unittest.TestCase):
             assert True
 
     def test_from_splits(self):
-        data = Reader().read('./tests/data.txt')
+        data = Reader().read('./tests/data.txt', fmt='UIRT')
         try:
             BaseMethod.from_splits(train_data=None, test_data=None)
         except ValueError:
@@ -71,6 +71,19 @@ class TestBaseMethod(unittest.TestCase):
                                     verbose=True)
         self.assertEqual(bm.total_users, 10)
         self.assertEqual(bm.total_items, 10)
+
+        bm = BaseMethod.from_splits(train_data=data[:-1] + [(data[0][0], data[1][1], 5.0, 1),
+                                                            (data[0][0], data[2][1], 5.0, float('inf'))],
+                                    test_data=data[-1:],
+                                    val_data=[(data[0][0], data[3][1], 5.0, 1)],
+                                    fmt='UIRT',
+                                    verbose=True)
+
+        self.assertEqual(bm.total_users, 10)
+        self.assertEqual(bm.total_items, 10)
+        user_idx = bm.train_set.uid_map[data[0][0]]
+        self.assertEqual(bm.train_set.user_data[user_idx][0][0], bm.train_set.iid_map[data[1][1]])
+        self.assertEqual(bm.train_set.user_data[user_idx][0][-1], bm.train_set.iid_map[data[2][1]])
 
     def test_with_modalities(self):
         data = Reader().read('./tests/data.txt')


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
Adding UIRT parser and update from_splits method appropriate with both UIR and UIRT format.
For UIRT format, data will be sorted chronologically before building.
<!--- Why is this change required? What problem does it solve? -->


### Related Issues
<!--- If it fixes an open issue, please link to the issue here. -->


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added tests.
- [x] I have updated the documentation accordingly.
- [ ] I have updated `README.md` (if you are adding a new model).
- [ ] I have updated `examples/README.md` (if you are adding a new example).
