### PR TITLE
Fix bug of Z dims in SoRec model

### DIFF
--- a/cornac/models/sorec/cython/sorec.cpp
+++ b/cornac/models/sorec/cython/sorec.cpp
@@ -3349,7 +3349,7 @@ static PyObject *__pyx_pf_6cornac_6models_5sorec_5sorec_sorec(CYTHON_UNUSED PyOb
  * 
  *     Z = init_params.get('Z', None)             # <<<<<<<<<<<<<<
  *     if Z is None:
- *         Z = normal((d, k), mean=0.0, std=0.001, random_state=rng, dtype=np.double)
+ *         Z = normal((n, k), mean=0.0, std=0.001, random_state=rng, dtype=np.double)
  */
   __pyx_t_1 = __Pyx_PyObject_GetAttrStr(__pyx_v_init_params, __pyx_n_s_get); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 73, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
@@ -3366,7 +3366,7 @@ static PyObject *__pyx_pf_6cornac_6models_5sorec_5sorec_sorec(CYTHON_UNUSED PyOb
  * 
  *     Z = init_params.get('Z', None)
  *     if Z is None:             # <<<<<<<<<<<<<<
- *         Z = normal((d, k), mean=0.0, std=0.001, random_state=rng, dtype=np.double)
+ *         Z = normal((n, k), mean=0.0, std=0.001, random_state=rng, dtype=np.double)
  * 
  */
   __pyx_t_9 = ((((PyObject *) __pyx_v_Z.memview) == Py_None) != 0);
@@ -3375,13 +3375,13 @@ static PyObject *__pyx_pf_6cornac_6models_5sorec_5sorec_sorec(CYTHON_UNUSED PyOb
     /* "cornac/models/sorec/cython/sorec.pyx":75
  *     Z = init_params.get('Z', None)
  *     if Z is None:
- *         Z = normal((d, k), mean=0.0, std=0.001, random_state=rng, dtype=np.double)             # <<<<<<<<<<<<<<
+ *         Z = normal((n, k), mean=0.0, std=0.001, random_state=rng, dtype=np.double)             # <<<<<<<<<<<<<<
  * 
  * 
  */
     __Pyx_GetModuleGlobalName(__pyx_t_3, __pyx_n_s_normal); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 75, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_3);
-    __pyx_t_1 = __Pyx_PyInt_From_int(__pyx_v_d); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 75, __pyx_L1_error)
+    __pyx_t_1 = __Pyx_PyInt_From_int(__pyx_v_n); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 75, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_1);
     __pyx_t_6 = __Pyx_PyInt_From_int(__pyx_v_k); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 75, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_6);
@@ -3426,7 +3426,7 @@ static PyObject *__pyx_pf_6cornac_6models_5sorec_5sorec_sorec(CYTHON_UNUSED PyOb
  * 
  *     Z = init_params.get('Z', None)
  *     if Z is None:             # <<<<<<<<<<<<<<
- *         Z = normal((d, k), mean=0.0, std=0.001, random_state=rng, dtype=np.double)
+ *         Z = normal((n, k), mean=0.0, std=0.001, random_state=rng, dtype=np.double)
  * 
  */
   }
@@ -18652,7 +18652,7 @@ static CYTHON_SMALL_CODE int __Pyx_InitCachedConstants(void) {
  * 
  *     Z = init_params.get('Z', None)             # <<<<<<<<<<<<<<
  *     if Z is None:
- *         Z = normal((d, k), mean=0.0, std=0.001, random_state=rng, dtype=np.double)
+ *         Z = normal((n, k), mean=0.0, std=0.001, random_state=rng, dtype=np.double)
  */
   __pyx_tuple__3 = PyTuple_Pack(2, __pyx_n_u_Z, Py_None); if (unlikely(!__pyx_tuple__3)) __PYX_ERR(0, 73, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_tuple__3);

--- a/cornac/models/sorec/cython/sorec.pyx
+++ b/cornac/models/sorec/cython/sorec.pyx
@@ -72,7 +72,7 @@ def sorec(int[:] rat_uid, int[:] rat_iid, float[:] rat_val, int[:] net_uid, int[
     
     Z = init_params.get('Z', None)
     if Z is None:
-        Z = normal((d, k), mean=0.0, std=0.001, random_state=rng, dtype=np.double)
+        Z = normal((n, k), mean=0.0, std=0.001, random_state=rng, dtype=np.double)
 
 
     # Optimization


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
Size of matrix Z is (`num_users`, `latent_dim`), previously was (`num_items`, `latent_dim`) 

### Related Issues
<!--- If it fixes an open issue, please link to the issue here. -->


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have added tests.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated `README.md` (if you are adding a new model).
- [ ] I have updated `examples/README.md` (if you are adding a new example).
- [ ] I have updated `datasets/README.md` (if you are adding a new dataset).
