### PR TITLE
Add PredefinedSplit eval_method

### DIFF
--- a/cornac/eval_methods/__init__.py
+++ b/cornac/eval_methods/__init__.py
@@ -18,12 +18,14 @@ from .base_method import ranking_eval
 
 from .base_method import BaseMethod
 from .ratio_split import RatioSplit
+from .predef_split import PredefinedSplit
 from .stratified_split import StratifiedSplit
 from .cross_validation import CrossValidation
 from .propensity_stratified_evaluation import PropensityStratifiedEvaluation
 
 __all__ = ['BaseMethod',
            'RatioSplit',
+           'PredefinedSplit'
            'StratifiedSplit',
            'CrossValidation',
            'PropensityStratifiedEvaluation']

--- a/cornac/eval_methods/predef_split.py
+++ b/cornac/eval_methods/predef_split.py
@@ -1,0 +1,59 @@
+# Copyright 2018 The Cornac Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ============================================================================
+
+from .base_method import BaseMethod
+
+class PredefinedSplit(BaseMethod):
+    """ Take a predefined training/testing split of your data set.
+    TODO: Add validation sets.
+
+    Parameters
+    ----------
+    data: array-like, required
+        Raw preference data in the triplet format [(user_id, item_id, rating_value)].
+
+    train_data: array-like, required
+        Raw preference training data in the triplet format [(user_id, item_id, rating_value)].
+
+    test_data: array-like, required
+        Raw preference testing data in the triplet format [(user_id, item_id, rating_value)].
+
+    val_data: array-like, optional, default: None
+        Raw preference validation data in the triplet format [(user_id, item_id, rating_value)].
+
+    rating_threshold: float, optional, default: 1.0
+        Threshold used to binarize rating values into positive or negative feedback for
+        model evaluation using ranking metrics (rating metrics are not affected).
+
+    seed: int, optional, default: None
+        Random seed for reproducibility.
+
+    exclude_unknowns: bool, optional, default: True
+        If `True`, unknown users and items will be ignored during model evaluation.
+
+    verbose: bool, optional, default: False
+        Output running log.
+
+    """
+
+    def __init__(self, data, train_data, test_data, val_data = None, rating_threshold=1.0, seed=None, exclude_unknowns=True, verbose=False, **kwargs):
+        super().__init__(data=data, rating_threshold=rating_threshold, seed=seed,
+                         exclude_unknowns=exclude_unknowns, verbose=verbose, **kwargs)
+
+
+        self._build(train_data, test_data, val_data)
+
+    def _build(self, train_data, test_data, val_data):
+        self.build(train_data=train_data, test_data=test_data, val_data=val_data)

--- a/docs/source/eval_methods.rst
+++ b/docs/source/eval_methods.rst
@@ -7,7 +7,7 @@ Base Method
 -----------------------------------------------
 .. automodule:: cornac.eval_methods.base_method
    :members:
-     
+
 Cross Validation
 ----------------------------------------------------
 .. automodule:: cornac.eval_methods.cross_validation
@@ -21,6 +21,11 @@ Propensity Stratified Evaluation
 Ratio Split
 -----------------------------------------------
 .. automodule:: cornac.eval_methods.ratio_split
+   :members:
+
+Predefined Split
+-----------------------------------------------
+.. automodule:: cornac.eval_methods.predef_split
    :members:
 
 Stratified Split

--- a/tests/cornac/eval_methods/test_predef_split.py
+++ b/tests/cornac/eval_methods/test_predef_split.py
@@ -1,0 +1,68 @@
+# Copyright 2018 The Cornac Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ============================================================================
+
+import unittest
+import itertools
+import random
+
+from cornac.eval_methods import PredefinedSplit
+from cornac.data import Reader
+from cornac.models import MF
+from cornac.metrics import MAE, Recall
+
+
+class TestPredefinedSplit(unittest.TestCase):
+
+    def setUp(self):
+        self.data = Reader().read('./tests/data.txt')
+
+
+    def test_builds(self):
+        try:
+            PredefinedSplit(self.data, self.data[:8], self.data[8:], seed=123, verbose=True)
+        except ValueError: # validation data is empty because unknowns are filtered
+            assert True
+
+        data = [(u, i, random.randint(1, 5))
+                for (u, i) in itertools.product(['u1', 'u2', 'u3', 'u4'],
+                                                ['i1', 'i2', 'i3', 'i4', 'i5'])]
+        predef_split = PredefinedSplit(data, data[0:16], data[16:18], val_data = data[18:20], seed=123, verbose=True)
+
+        self.assertTrue(predef_split.train_size == 16)
+        self.assertTrue(predef_split.test_size == 2)
+        self.assertTrue(predef_split.val_size == 2)
+
+    def test_evaluate(self):
+        ratio_split = PredefinedSplit(self.data, self.data[:8], self.data[8:], exclude_unknowns=False, verbose=True)
+        ratio_split.evaluate(MF(), [MAE(), Recall()], user_based=False)
+
+        ratio_split = PredefinedSplit(self.data, self.data[:8], self.data[8:], exclude_unknowns=False, verbose=True)
+        ratio_split.evaluate(MF(), [MAE(), Recall()], user_based=False)
+
+        users = []
+        items = []
+        for u, i, r in self.data:
+            users.append(u)
+            items.append(i)
+        for u in users:
+            for i in items:
+                self.data.append((u, i, 5))
+
+        ratio_split = PredefinedSplit(self.data, self.data[:8], self.data[8:], exclude_unknowns=False, verbose=True)
+        ratio_split.evaluate(MF(), [MAE(), Recall()], user_based=True)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
I have added a class similar to RatioSplit that bypasses random shuffling of train/test/val data splits.

I have removed the <test_size>, <val_size> parameters relative to RatioSplit and introduced
parameters <train_data>, <test_data>, and <val_data>.

<!--- Why is this change required? What problem does it solve? -->
I have not found a feature in the current master (2de81e17b83794a3e7cbc4f47d6bd9061694b5d1) that allows me to use my own train/test/val splits. I need this to accomodate for comparability to my previous evaluations that I did independently from cornac.

### Related Issues
<!--- If it fixes an open issue, please link to the issue here. -->
No, as far as I could see.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

TEichinger: I have tested the example in the Readme.md by switching RatioSplit with my proposed PredefinedSplit. I also added a test, but did not know how to see whether the test is successful. I ran the file as a script but received an error that it could not load the data.txt file.
- [x?] I have added tests.
TEichinger: I have just added a pointer in the eval_methods.rst file, does this suffice? 
- [x] I have updated the documentation accordingly. 