### PR TITLE
Specify numpy version for each Python version

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -34,10 +34,24 @@ jobs:
     - name: Upgrade pip wheel setuptools
       run: python -m pip install wheel setuptools pip --upgrade
 
-    - name: Install numpy
-      run: |
-        python -m pip install numpy==1.24.3
-        python -c "import numpy; print(numpy.__version__)"
+    - name: Install numpy for Python 3.8
+      if: matrix.python-version == '3.8'
+      run: python -m pip install numpy==1.20.3
+        
+    - name: Install numpy for Python 3.9
+      if: matrix.python-version == '3.9'
+      run: python -m pip install numpy==1.21.6
+
+    - name: Install numpy for Python 3.10
+      if: matrix.python-version == '3.10'
+      run: python -m pip install numpy==1.22.4
+
+    - name: Install numpy for Python 3.11
+      if: matrix.python-version == '3.11'
+      run: python -m pip install numpy==1.24.3
+
+    - name: Display numpy version
+      run: python -c "import numpy; print(numpy.__version__)"
 
     - name: Install other dependencies
       run: |

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -33,10 +33,24 @@ jobs:
     - name: Display Python version
       run: python -c "import sys; print(sys.version)"
     
-    - name: Install numpy
-      run: |
-        python -m pip install numpy==1.24.3
-        python -c "import numpy; print(numpy.__version__)"
+    - name: Install numpy for Python 3.8
+      if: matrix.python-version == '3.8'
+      run: python -m pip install numpy==1.20.3
+        
+    - name: Install numpy for Python 3.9
+      if: matrix.python-version == '3.9'
+      run: python -m pip install numpy==1.21.6
+
+    - name: Install numpy for Python 3.10
+      if: matrix.python-version == '3.10'
+      run: python -m pip install numpy==1.22.4
+
+    - name: Install numpy for Python 3.11
+      if: matrix.python-version == '3.11'
+      run: python -m pip install numpy==1.24.3
+
+    - name: Display numpy version
+      run: python -c "import numpy; print(numpy.__version__)"
 
     - name: Install other dependencies
       run: |
@@ -77,7 +91,7 @@ jobs:
 
     - name: Install numpy
       run: |
-        python -m pip install numpy==1.24.3
+        python -m pip install numpy==1.22.4
         python -c "import numpy; print(numpy.__version__)"
 
     - name: Install other dependencies


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
Need to specify numpy version to be more compatible with Google Colab. Specifically, current Colab env uses Python 3.10 with numpy 1.22.4

### Related Issues
<!--- If it fixes an open issue, please link to the issue here. -->


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have added tests.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated `README.md` (if you are adding a new model).
- [ ] I have updated `examples/README.md` (if you are adding a new example).
- [ ] I have updated `datasets/README.md` (if you are adding a new dataset).
