### PR TITLE
Add missing default scores when item_idx is none

### DIFF
--- a/cornac/models/gcmc/recom_gcmc.py
+++ b/cornac/models/gcmc/recom_gcmc.py
@@ -215,9 +215,11 @@ class GCMC(Recommender):
             # Return scores of all items for a given user
             # - If item does not exist in test_set, we provide a default score
             #   (as set in default_dict initialisation)
-            return [
-                self.u_i_rating_dict[f"{user_idx}-{idx}"]
+            import numpy as np
+
+            return np.array([
+                self.u_i_rating_dict.get(f"{user_idx}-{idx}", self.default_score())
                 for idx in range(self.train_set.total_items)
-            ]
+            ])
         # Return score of known user/item
         return self.u_i_rating_dict.get(f"{user_idx}-{item_idx}", self.default_score())


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
For instances when predicting scores and item_idx is none:
- It currently throws a "invalid key" error for something that has not been seen 

Solved by returning a default score instead.

### Related Issues
<!--- If it fixes an open issue, please link to the issue here. -->


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have added tests.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated `README.md` (if you are adding a new model).
- [ ] I have updated `examples/README.md` (if you are adding a new example).
- [ ] I have updated `datasets/README.md` (if you are adding a new dataset).
