### PR TITLE
Add simple model serving

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,17 +105,17 @@ For more details, please take a look at our [examples](examples) as well as [tut
 
 ## Simple model serving
 
-Here we provide a simple way to serve Cornac model with a standalone service. This is by no means an optimized way for model deployment in production, though it is very handy to test your model or create a demo application. Supposed that we use the trained BPR model from previous example, we first need to save the model:
+Here, we provide a simple way to serve a Cornac model by launching a standalone web service. While this will not be an optimized service for model deployment in production, it is quite handy for testing or creating a demo application. Supposed that we use the trained BPR from previous example, we first need to save the model:
 ```python
 bpr.save("save_dir")
 ```
-The model can be served easily by triggering Cornac serving module:
+The model can be deployed easily by triggering Cornac serving module:
 ```bash
 $ python -m cornac.serving --model_dir save_dir/BPR --model_class cornac.models.BPR
 
 # Serving BPR at port 8080
 ```
-Here you go, your model is now served. Let's get `top-5` item recommendations for the user `"63"`:
+Here you go, your model service is now ready. Let's get `top-5` item recommendations for the user `"63"`:
 ```bash
 $ curl http://127.0.0.1:8080/recommend \
     --request POST \

--- a/README.md
+++ b/README.md
@@ -115,13 +115,13 @@ $ python -m cornac.serving --model_dir save_dir/BPR --model_class cornac.models.
 
 # Serving BPR at port 8080
 ```
-Here you go, your model service is now ready. Let's get `top-5` item recommendations for the user `"63"`:
+Here we go, our model service is now ready. Let's get `top-5` item recommendations for the user `"63"`:
 ```bash
 $ curl -X GET "http://127.0.0.1:8080/recommend?uid=63&k=5&remove_seen=false"
 
 # Response: {"recommendations": ["50", "181", "100", "258", "286"], "query": {"uid": "63", "k": 5, "remove_seen": false}}
 ```
-If you would like to remove seen items during training, you need to provide `train_set` when starting the serving service.
+If we want to remove seen items during training, we need to provide `train_set` when starting the serving service.
 ```bash
 $ python -m cornac.serving --help
 

--- a/README.md
+++ b/README.md
@@ -117,12 +117,24 @@ $ python -m cornac.serving --model_dir save_dir/BPR --model_class cornac.models.
 ```
 Here you go, your model service is now ready. Let's get `top-5` item recommendations for the user `"63"`:
 ```bash
-$ curl http://127.0.0.1:8080/recommend \
-    --request POST \
-    --header "Content-Type: application/json" \
-    --data '{"uid":"63", "k": 5}'
+$ curl -X GET "http://127.0.0.1:8080/recommend?uid=63&k=5&remove_seen=false"
 
-# Response: {"recommendations": ["50", "181", "100", "258", "286"], "data_received": {"uid": "63", "k": 5}}
+# Response: {"recommendations": ["50", "181", "100", "258", "286"], "query": {"uid": "63", "k": 5, "remove_seen": false}}
+```
+If you would like to remove seen items during training, you need to provide `train_set` when starting the serving service.
+```bash
+$ python -m cornac.serving --help
+
+usage: serving.py [-h] --model_dir MODEL_DIR [--model_class MODEL_CLASS] [--train_set TRAIN_SET] [--port PORT]
+
+Cornac model serving
+
+options:
+  -h, --help                    show this help message and exit
+  --model_dir MODEL_DIR         path to directory where the model was saved
+  --model_class MODEL_CLASS     class of the model being deployed
+  --train_set TRAIN_SET         path to pickled file of the train_set (to remove seen items)
+  --port PORT                   service port
 ```
 
 ## Models

--- a/cornac/serving.py
+++ b/cornac/serving.py
@@ -1,0 +1,132 @@
+# Copyright 2018 The Cornac Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ============================================================================
+
+"""CLI entry point for model serving.
+"""
+
+import argparse
+import sys
+import json
+import pickle
+import http.server
+import socketserver
+
+
+class ModelRequestHandler(http.server.BaseHTTPRequestHandler):
+    def _set_response(self, status_code=200, content_type="application/json"):
+        self.send_response(status_code)
+        self.send_header("Content-type", content_type)
+        self.end_headers()
+
+    def do_GET(self):
+        if self.path == "/":
+            self._set_response()
+            response_data = {"message": "Cornac model serving."}
+            self.wfile.write(json.dumps(response_data).encode())
+        else:
+            self.send_error(404, "Endpoint not found")
+
+    def do_POST(self):
+        if self.path == "/recommend":
+            content_length = int(self.headers["Content-Length"])
+            post_data = self.rfile.read(content_length).decode("utf-8")
+            post_data = json.loads(post_data)
+
+            # TODO: input validation
+            user_id = str(post_data["uid"])
+            k = -1 if "k" not in post_data else int(post_data["k"])
+            remove_seen = (
+                False
+                if "remove_seen" not in post_data
+                else bool(post_data["remove_seen"])
+            )
+
+            response_data = {
+                "recommendations": self.server.model.recommend(
+                    user_id=user_id,
+                    k=k,
+                    remove_seen=remove_seen,
+                    train_set=self.server.train_set,
+                ),
+                "data_received": post_data,
+            }
+
+            self._set_response()
+            self.wfile.write(json.dumps(response_data).encode())
+        else:
+            self.send_error(404, "Endpoint not found")
+
+
+def import_model_class(model_class):
+    components = model_class.split(".")
+    mod = __import__(".".join(components[:-1]), fromlist=[components[-1]])
+    klass = getattr(mod, components[-1])
+    return klass
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Cornac model serving")
+    parser.add_argument(
+        "--model_dir",
+        type=str,
+        required=True,
+        help="Path to directory where the model was saved",
+    )
+    parser.add_argument(
+        "--model_class",
+        type=str,
+        default="cornac.models.Recommender",
+        help="Cornac class of the model which is being deployed",
+    )
+    parser.add_argument(
+        "--train_set",
+        type=str,
+        default=None,
+        help="Path to pickled file of the train_set (used to remove seen items)",
+    )
+    parser.add_argument(
+        "--port",
+        type=int,
+        default=8080,
+        help="Service port",
+    )
+
+    return parser.parse_args(sys.argv[1:])
+
+
+def main():
+    args = parse_args()
+
+    # Load model/train_set if provided
+    httpd = socketserver.TCPServer(("", args.port), ModelRequestHandler)
+    httpd.model = import_model_class(args.model_class).load(args.model_dir)
+    httpd.train_set = None
+    if args.train_set is not None:
+        with open(args.train_set, "rb") as f:
+            httpd.train_set = pickle.load(f)
+
+    # Start service
+    try:
+        print(f"Serving {httpd.model.name} at port {args.port}")
+        httpd.serve_forever()
+    except KeyboardInterrupt:
+        pass
+
+    httpd.server_close()
+    print("Server stopped.")
+
+
+if __name__ == "__main__":
+    main()

--- a/cornac/serving.py
+++ b/cornac/serving.py
@@ -78,25 +78,25 @@ def parse_args():
         "--model_dir",
         type=str,
         required=True,
-        help="Path to directory where the model was saved",
+        help="path to directory where the model was saved",
     )
     parser.add_argument(
         "--model_class",
         type=str,
         default="cornac.models.Recommender",
-        help="Cornac class of the model which is being deployed",
+        help="class of the model being deployed",
     )
     parser.add_argument(
         "--train_set",
         type=str,
         default=None,
-        help="Path to pickled file of the train_set (used to remove seen items)",
+        help="path to pickled file of the train_set (to remove seen items)",
     )
     parser.add_argument(
         "--port",
         type=int,
         default=8080,
-        help="Service port",
+        help="service port",
     )
 
     return parser.parse_args(sys.argv[1:])


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
Adding a simple method to serve model with launching a standalone web service. Good enough for model testing or creating a demo application.

### Related Issues
<!--- If it fixes an open issue, please link to the issue here. -->


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have added tests.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated `README.md` (if you are adding a new model).
- [ ] I have updated `examples/README.md` (if you are adding a new example).
- [ ] I have updated `datasets/README.md` (if you are adding a new dataset).
