### PR TITLE
Remove exception checking for _dot()

### DIFF
--- a/cornac/utils/fast_dot.pyx
+++ b/cornac/utils/fast_dot.pyx
@@ -22,8 +22,13 @@ from cython.parallel import prange
 from scipy.linalg.cython_blas cimport sdot, ddot
 
 
-cdef floating _dot(int n, floating *x, int incx,
-                   floating *y, int incy) nogil:
+cdef floating _dot(
+    int n, 
+    floating *x, 
+    int incx,
+    floating *y, 
+    int incy
+) noexcept nogil:
     if floating is float:
         return sdot(&n, x, &incx, y, &incy)
     else:


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
Cython appears to check for exception of `_dot()`, which creates overhead especially with Intel chip (not to be the case for AMD). This fix is to remove such checking. 

### Related Issues
<!--- If it fixes an open issue, please link to the issue here. -->


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have added tests.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated `README.md` (if you are adding a new model).
- [ ] I have updated `examples/README.md` (if you are adding a new example).
- [ ] I have updated `datasets/README.md` (if you are adding a new dataset).
