### PR TITLE
Make use of verbose setting in Experiment

### DIFF
--- a/cornac/experiment/experiment.py
+++ b/cornac/experiment/experiment.py
@@ -46,6 +46,10 @@ class Experiment:
     show_validation: bool, optional, default: True 
         Whether to show the results on validation set (if exists).
 
+    verbose: bool, optional, default: False
+        Output running log/progress during model training and evaluation.
+        If verbose is True, it will overwrite verbosity setting of evaluation method and models.
+        
     save_dir: str, optional, default: None
         Path to a directory for storing trained models and logs. If None, 
         models will NOT be stored and logs will be saved in the current working directory.
@@ -126,6 +130,13 @@ class Experiment:
     def run(self):
         """Run the Cornac experiment"""
         self._create_result()
+
+        # overwrite verbosity setting of evaluation method and models
+        # if Experiment verbose is True
+        if self.verbose:
+            self.eval_method.verbose = self.verbose
+            for model in self.models:
+                model.verbose = self.verbose
 
         for model in self.models:
             test_result, val_result = self.eval_method.evaluate(


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
If the verbosity setting of Experiment is set to True, we will output running log/progress during model training and evaluation. It makes sense that this verbosity setting is reflected for the whole Experiment. Less tedious for users.

### Related Issues
<!--- If it fixes an open issue, please link to the issue here. -->
#560

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have added tests.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated `README.md` (if you are adding a new model).
- [ ] I have updated `examples/README.md` (if you are adding a new example).
- [ ] I have updated `datasets/README.md` (if you are adding a new dataset).
