### PR TITLE
Add back Circle CI for publishing code coverage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,33 @@
+# This workflow will build and test, then publish code coverage to codecov.io
+version: 2.1
+
+orbs:
+  python: circleci/python@1.5.0
+
+jobs:
+  build-and-test: 
+    docker:
+      - image: cimg/python:3.10.2
+    steps:
+      - checkout
+      - python/install-packages:
+          pkg-manager: pip
+      - run:
+          name: Install dependencies
+          no_output_timeout: 30m
+          command: |
+            sudo pip install --upgrade pip
+            sudo pip install --only-binary=numpy,scipy numpy==1.22.4 scipy Cython pytest pytest-cov codecov
+            sudo pip install -e .[tests]
+      - run:
+          name: Run tests
+          no_output_timeout: 30m
+          # This assumes pytest is installed via the install-package step above
+          command: |
+            python -m pytest --cov=cornac
+            codecov || echo "codecov failed"
+
+workflows:
+  codecov:
+    jobs:
+      - build-and-test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@
 version: 2.1
 
 orbs:
-  python: circleci/python@1.5.0
+  python: circleci/python@2.1.1
 
 jobs:
   build-and-test: 


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
Previously, we had Circle CI workflow to publish code coverage to codecov.io which shows the badge in our README. It stopped working at some point, we then removed it together with updating GitHub actions. Let's try to add it back for tracking test coverage. Alternatively, this could be added as part of the GitHub actions.

### Related Issues
<!--- If it fixes an open issue, please link to the issue here. -->


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have added tests.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated `README.md` (if you are adding a new model).
- [ ] I have updated `examples/README.md` (if you are adding a new example).
- [ ] I have updated `datasets/README.md` (if you are adding a new dataset).
