### PR TITLE
Enhance serving evaluation endpoints

### DIFF
--- a/cornac/serving/app.py
+++ b/cornac/serving/app.py
@@ -313,12 +313,15 @@ def process_evaluation(test_set, query, exclude_unknowns):
         user_based=user_based,
         verbose=False,
     )
-    
+
+    uid_map = train_set.uid_map
+    inversed_uid_map = {str(v): k for k, v in uid_map.items()}
+
     # change metric_user_results inner keys to string
     metric_user_results = {}
     for metric, user_results in result.metric_user_results.items():
         metric_user_results[metric] = {
-            str(k): v for k, v in user_results.items()
+            inversed_uid_map[str(k)]: v for k, v in user_results.items()
         }
 
     # response

--- a/cornac/serving/app.py
+++ b/cornac/serving/app.py
@@ -215,7 +215,9 @@ def evaluate():
         data = reader.read(data_fpath, fmt="UIR", sep=",")
 
     if not data:
-        raise ValueError("No data available to evaluate the model.")
+        response = make_response("No feedback has been provided so far. No data available to evaluate the model.")
+        response.status_code = 400
+        abort(response)
 
     test_set = Dataset.build(
         data,
@@ -244,7 +246,9 @@ def validate_query(query):
 def evaluate_json(exclude_unknowns, query, data):
     # read data
     if not data:
-        raise ValueError("No data available to evaluate the model.")
+        response = make_response("'use_data' is empty. No data available to evaluate the model.")
+        response.status_code = 400
+        abort(response)
 
     # convert rows of data to tuples
     for i, row in enumerate(data):

--- a/cornac/serving/app.py
+++ b/cornac/serving/app.py
@@ -26,7 +26,7 @@ from cornac.eval_methods import BaseMethod
 from cornac.metrics import *
 
 try:
-    from flask import Flask, jsonify, request, abort
+    from flask import Flask, jsonify, request, abort, make_response
 except ImportError:
     exit("Flask is required in order to serve models.\n" + "Run: pip3 install Flask")
 
@@ -231,10 +231,14 @@ def evaluate():
 def validate_query(query):
     query_metrics = query.get("metrics")
 
-    if query_metrics is None:
-        abort(400, "metrics is required")
+    if not query_metrics:
+        response = make_response("metrics is required")
+        response.status_code = 400
+        abort(response)
     elif not isinstance(query_metrics, list):
-        abort(400, "metrics must be an array of metrics")
+        response = make_response("metrics must be an array of metrics")
+        response.status_code = 400
+        abort(response)
 
 
 def evaluate_json(exclude_unknowns, query, data):

--- a/cornac/serving/app.py
+++ b/cornac/serving/app.py
@@ -325,7 +325,6 @@ def process_evaluation(test_set, query, exclude_unknowns):
     response = {
         "result": result.metric_avg_results,
         "user_result": metric_user_results,
-        "query": query,
     }
 
     return jsonify(response), 200

--- a/cornac/serving/app.py
+++ b/cornac/serving/app.py
@@ -314,14 +314,11 @@ def process_evaluation(test_set, query, exclude_unknowns):
         verbose=False,
     )
 
-    uid_map = train_set.uid_map
-    inversed_uid_map = {str(v): k for k, v in uid_map.items()}
-
-    # change metric_user_results inner keys to string
+    # map user index back into the original user ID
     metric_user_results = {}
     for metric, user_results in result.metric_user_results.items():
         metric_user_results[metric] = {
-            inversed_uid_map[str(k)]: v for k, v in user_results.items()
+            train_set.user_ids[int(k)]: v for k, v in user_results.items()
         }
 
     # response

--- a/tests/cornac/serving/test_app.py
+++ b/tests/cornac/serving/test_app.py
@@ -111,3 +111,26 @@ def test_evalulate_incorrect_post(client):
     response = client.post('/evaluate')
     assert response.status_code == 415  # bad request, expect json
 
+
+def test_evaluate_missing_metrics(client):
+    json_data = {
+        'metrics': []
+    }
+    response = client.post('/evaluate', json=json_data)
+    assert response.status_code == 400
+    assert response.data == b'metrics is required'
+
+
+def test_evaluate_not_list_metrics(client):
+    json_data = {
+        'metrics': 'RMSE()'
+    }
+    response = client.post('/evaluate', json=json_data)
+    assert response.status_code == 400
+    assert response.data == b'metrics must be an array of metrics'
+
+
+def test_recommend_missing_uid(client):
+    response = client.get('/recommend?k=5')
+    assert response.status_code == 400
+    assert response.data == b'uid is required'

--- a/tests/cornac/serving/test_app.py
+++ b/tests/cornac/serving/test_app.py
@@ -96,9 +96,10 @@ def test_evaluate_json(client):
     response = client.post('/evaluate', json=json_data)
     # assert response.content_type == 'application/json'
     assert response.status_code == 200
-    assert len(response.json['query']['metrics']) == 2
     assert 'RMSE' in response.json['result']
     assert 'Recall@5' in response.json['result']
+    assert 'RMSE' in response.json['user_result']
+    assert 'Recall@5' in response.json['user_result']
 
 
 def test_evalulate_incorrect_get(client):

--- a/tests/cornac/serving/test_app.py
+++ b/tests/cornac/serving/test_app.py
@@ -134,3 +134,29 @@ def test_recommend_missing_uid(client):
     response = client.get('/recommend?k=5')
     assert response.status_code == 400
     assert response.data == b'uid is required'
+
+
+def test_evaluate_use_data(client):
+    json_data = {
+        'metrics': ['RMSE()', 'Recall(k=5)'],
+        'use_data': [['930', '795', 5], ['195', '795', 3]]
+    }
+    response = client.post('/evaluate', json=json_data)
+    # assert response.content_type == 'application/json'
+    assert response.status_code == 200
+    assert 'RMSE' in response.json['result']
+    assert 'Recall@5' in response.json['result']
+    assert 'RMSE' in response.json['user_result']
+    assert 'Recall@5' in response.json['user_result']
+
+
+def test_evaluate_use_data_empty(client):
+    json_data = {
+        'metrics': ['RMSE()', 'Recall(k=5)'],
+        'use_data': []
+    }
+    response = client.post('/evaluate', json=json_data)
+    assert response.status_code == 400
+    assert response.data == b"'use_data' is empty. No data available to evaluate the model."
+
+

--- a/tests/cornac/serving/test_app.py
+++ b/tests/cornac/serving/test_app.py
@@ -139,7 +139,7 @@ def test_recommend_missing_uid(client):
 def test_evaluate_use_data(client):
     json_data = {
         'metrics': ['RMSE()', 'Recall(k=5)'],
-        'use_data': [['930', '795', 5], ['195', '795', 3]]
+        'data': [['930', '795', 5], ['195', '795', 3]]
     }
     response = client.post('/evaluate', json=json_data)
     # assert response.content_type == 'application/json'
@@ -153,10 +153,10 @@ def test_evaluate_use_data(client):
 def test_evaluate_use_data_empty(client):
     json_data = {
         'metrics': ['RMSE()', 'Recall(k=5)'],
-        'use_data': []
+        'data': []
     }
     response = client.post('/evaluate', json=json_data)
     assert response.status_code == 400
-    assert response.data == b"'use_data' is empty. No data available to evaluate the model."
+    assert response.data == b"No feedback has been provided so far. No data available to evaluate the model."
 
 


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

This PR involves 2 changes to the serving functions:
1. Add `metric_user_results` to evaluation results as `user_result`
2. Modified `/evaluation` endpoint to accept evaluation data in the form of a json if `data` is included. Else, it will follow previous behavior of using feedback data added through the `/feedback` endpoint.
3. `query` is removed from reponse


**Sample request for `/evaluation`:**
```
{
    "metrics": ["RMSE()", "NDCG(k=10)"],
    "data": [
        ["123", "1539", 1],
        ["123", "2", 1],
        ["124", "1", 1]
    ]
}
```

**Response:**
```
{
    "result": {
        "NDCG@10": 0.3175294778309396,
        "RMSE": 2.781925109617526
    },
    "user_result": {
        "NDCG@10": {
            "123": 0.20438239758848611,
            "124": 0.43067655807339306
        },
        "RMSE": {
            "123": 2.244862849697699,
            "124": 3.3189873695373535
        }
    }
}
```


### Related Issues
<!--- If it fixes an open issue, please link to the issue here. -->


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have added tests.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated `README.md` (if you are adding a new model).
- [ ] I have updated `examples/README.md` (if you are adding a new example).
- [ ] I have updated `datasets/README.md` (if you are adding a new dataset).
