### PR TITLE
Update docker-compose serving image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.7'
 
 services:
   cornac:
-    image: registry.preferred.ai/cornac/cornac-server:latest
+    image: ghcr.io/preferredai/cornac-server:latest
     volumes:
       - $PWD/save_dir:/app/cornac/serving/save_dir
       - cornacvol:/app/cornac/serving/data


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
This PR changes the docker-compose to move from our internal docker registry to `ghcr.io`. 


### Related Issues
<!--- If it fixes an open issue, please link to the issue here. -->


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have added tests.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated `README.md` (if you are adding a new model).
- [ ] I have updated `examples/README.md` (if you are adding a new example).
- [ ] I have updated `datasets/README.md` (if you are adding a new dataset).
