### PR TITLE
Add more build platforms in GitHub Actions

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -16,18 +16,18 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-latest, ubuntu-latest, macos-13, macos-14]
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
-        exclude:
+        # os: [windows-latest, ubuntu-latest, macos-13, macos-14]
+        # python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        # exclude:
+        #   - os: macos-14
+        #     python-version: "3.8"
+        #   - os: macos-14
+        #     python-version: "3.9"
+        include:
           - os: macos-14
             python-version: "3.8"
           - os: macos-14
             python-version: "3.9"
-        include:
-          - os: macos-14
-            python-version: "pypy3.8"
-          - os: macos-14
-            python-version: "pypy3.9"
 
     steps:
     - name: Get number of CPU cores
@@ -37,53 +37,64 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Setup Python ${{ matrix.python-version }}
+      if: ${{ (matrix.os != 'macos-14') || ((matrix.os == 'macos-14') && (matrix.python-version != '3.8') && (matrix.python-version != '3.9')) }}
       uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
         cache: 'pip'
 
+    - name: Setup Python 3.8-3.9 - macos-arm
+      if: ${{ (matrix.os == 'macos-14') && ((matrix.python-version == '3.8') || (matrix.python-version == '3.9')) }}
+      run: |
+        brew update
+        brew install python@${{ matrix.python-version }}
+        curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
+        python${{ matrix.python-version }} get-pip.py
+
     - name: Display Python version
-      run: python -c "import sys; print(sys.version)"
+      run: | 
+        python -c "import sys; print(sys.version)"
+        pip --version
 
     - name: Upgrade pip wheel setuptools
-      run: python -m pip install wheel setuptools pip --upgrade
+      run: pip install wheel setuptools pip --upgrade
 
     - name: Install numpy for Python 3.8
       if: matrix.python-version == '3.8'
-      run: python -m pip install numpy==1.20.3
+      run: pip install numpy==1.20.3
         
     - name: Install numpy for Python 3.9
       if: matrix.python-version == '3.9'
-      run: python -m pip install numpy==1.20.3
+      run: pip install numpy==1.20.3
 
     - name: Install numpy for Python 3.10
       if: matrix.python-version == '3.10'
-      run: python -m pip install numpy==1.22.4
+      run: pip install numpy==1.22.4
 
     - name: Install numpy for Python 3.11
       if: matrix.python-version == '3.11'
-      run: python -m pip install numpy==1.24.3
+      run: pip install numpy==1.24.3
 
     - name: Install numpy for Python 3.12
       if: matrix.python-version == '3.12'
-      run: python -m pip install numpy==1.26.4
+      run: pip install numpy==1.26.4
 
     - name: Install numpy for Pypy 3.8 arm64
       if: matrix.python-version == 'pypy3.8'
-      run: python -m pip install numpy==1.20.3
+      run: pip install numpy==1.20.3
         
     - name: Install numpy for Pypy 3.9 arm64
       if: matrix.python-version == 'pypy3.9'
-      run: python -m pip install numpy==1.20.3
+      run: pip install numpy==1.20.3
     
     - name: Display numpy version
       run: python -c "import numpy; print(numpy.__version__)"
 
     - name: Install other dependencies
       run: |
-        python -m pip install scipy Cython pytest pytest-cov flake8
+        pip install scipy Cython pytest pytest-cov flake8
         python setup.py build_ext -j${{ steps.cpu-cores.outputs.count }}
-        python -m pip install -e .[tests]
+        pip install -e .[tests]
 
     - name: Lint with flake8
       run: |
@@ -94,4 +105,4 @@ jobs:
     
     - name: Test with pytest
       run: |
-        python -m pytest --cov=cornac
+        pytest --cov=cornac

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -44,7 +44,9 @@ jobs:
 
     - name: Create Python alias for Windows 
       if: matrix.os == 'windows-latest'
-      run: Set-Alias -Name python${{ matrix.python-version }} -Value ${{ steps.pysetup.outputs.python-path }}
+      run: |
+        $newPath = ${{ steps.pysetup.outputs.python-path }} -replace "python.exe", "python${{ matrix.python-version }}.exe"
+        mklink "$newPath" "${{ steps.pysetup.outputs.python-path }}"
 
     - name: Display Python and Pip versions
       run: | 

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -87,7 +87,7 @@ jobs:
     #     brew install python@${{ matrix.python-version }}
 
     - name: Setup Python
-      uses: actions/python-version@v3
+      uses: actions/python-versions@v3
       with:
         python-version: ${{ matrix.python-version }}
         cache: 'pip'

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-latest, ubuntu-latest, macos-13, macos-14]
+        os: [windows-latest]
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
         
     steps:
@@ -29,6 +29,7 @@ jobs:
     - name: Setup Python ${{ matrix.python-version }}
       if: ${{ (matrix.os != 'macos-14') || ((matrix.os == 'macos-14') && (matrix.python-version != '3.8') && (matrix.python-version != '3.9')) }}
       uses: actions/setup-python@v5
+      id: pysetup
       with:
         python-version: ${{ matrix.python-version }}
         cache: 'pip'
@@ -40,6 +41,10 @@ jobs:
         brew install python@${{ matrix.python-version }}
         curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
         python${{ matrix.python-version }} get-pip.py
+
+    - name: Create Python alias for Windows 
+      if: matrix.os == 'windows-latest'
+      run: New-Alias -Name "python${{ matrix.python-version }}" python
 
     - name: Display Python and Pip versions
       run: | 

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -16,23 +16,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # os: [windows-latest, ubuntu-latest, macos-13, macos-14]
-        # python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
-        # exclude:
-        #   - os: macos-14
-        #     python-version: "3.8"
-        #   - os: macos-14
-        #     python-version: "3.9"
-        include:
-          - os: macos-14
-            python-version: "3.8"
-          - os: macos-14
-            python-version: "3.9"
-          - os: macos-14
-            python-version: "3.10"
-          - os: macos-13
-            python-version: "3.10"
-
+        os: [windows-latest, ubuntu-latest, macos-13, macos-14]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        
     steps:
     - name: Get number of CPU cores
       uses: SimenB/github-actions-cpu-cores@v2
@@ -55,9 +41,9 @@ jobs:
         curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
         python${{ matrix.python-version }} get-pip.py
 
-    - name: Display Python version
+    - name: Display Python and Pip versions
       run: | 
-        python -c "import sys; print(sys.version)"
+        python${{ matrix.python-version }} -c "import sys; print(sys.version)"
         pip --version
 
     - name: Upgrade pip wheel setuptools

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -61,11 +61,11 @@ jobs:
 
     - name: Install numpy for Python 3.8
       if: matrix.python-version == '3.8'
-      run: pip install numpy==1.20.3
+      run: pip install numpy==1.22.4
         
     - name: Install numpy for Python 3.9
       if: matrix.python-version == '3.9'
-      run: pip install numpy==1.20.3
+      run: pip install numpy==1.22.4
 
     - name: Install numpy for Python 3.10
       if: matrix.python-version == '3.10'
@@ -78,14 +78,6 @@ jobs:
     - name: Install numpy for Python 3.12
       if: matrix.python-version == '3.12'
       run: pip install numpy==1.26.4
-
-    - name: Install numpy for Pypy 3.8 arm64
-      if: matrix.python-version == 'pypy3.8'
-      run: pip install numpy==1.20.3
-        
-    - name: Install numpy for Pypy 3.9 arm64
-      if: matrix.python-version == 'pypy3.9'
-      run: pip install numpy==1.20.3
     
     - name: Display numpy version
       run: python -c "import numpy; print(numpy.__version__)"

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -83,7 +83,7 @@ jobs:
       if: ${{ (matrix.os == 'macos-14') && ((matrix.python-version == '3.8') || (matrix.python-version == '3.9')) }}
       run: |
         brew update
-        brew uninstall python3
+        brew uninstall --ignore-dependencies python3
         brew install python@${{ matrix.python-version }}
 
     - name: Display Python version

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -123,7 +123,7 @@ jobs:
 
     - name: Install numpy for Python 3.12
       if: matrix.python-version == '3.12'
-      run: python -m pip install numpy==1.24.3
+      run: python -m pip install numpy==1.26.4
 
     - name: Display numpy version
       run: python -c "import numpy; print(numpy.__version__)"

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -72,11 +72,20 @@ jobs:
 
     - uses: actions/checkout@v2
     
-    - name: Setup Python ${{ matrix.python-version }}
+    - name: Setup Python ${{ matrix.os }} - ${{ matrix.python-version }}
+      if: ${{ (matrix.os != 'macos-14') && (matrix.python-version != '3.8') && (matrix.python-version != '3.9') }}
       uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
         cache: 'pip'
+
+    - name: Setup Python and pip for macos-arm - Python 3.8-3.9
+      if: ${{ (matrix.os == 'macos-14') && ((matrix.python-version == '3.8') || (matrix.python-version != '3.9')) }}
+      run: |
+        brew update
+        brew install python@${{ matrix.python-version }}
+        curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
+        python${{ matrix.python-version }} get-pip.py
 
     - name: Display Python version
       run: python -c "import sys; print(sys.version)"

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -83,10 +83,8 @@ jobs:
       if: ${{ (matrix.os == 'macos-14') && ((matrix.python-version == '3.8') || (matrix.python-version == '3.9')) }}
       run: |
         brew update
+        brew uninstall python3
         brew install python@${{ matrix.python-version }}
-        # curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
-        # python${{ matrix.python-version }} get-pip.py
-        export PATH=$(brew --prefix python@${{ matrix.python-version }})/libexec/bin:$PATH
 
     - name: Display Python version
       run: python -c "import sys; print(sys.version)"

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -17,7 +17,13 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-latest, ubuntu-latest, macos-13, macos-14]
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        # python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        versions:
+          - { python: "3.8", numpy: 1.22.4 }
+          - { python: "3.9", numpy: 1.22.4 }
+          - { python: "3.10", numpy: 1.22.4 }
+          - { python: "3.11", numpy: 1.24.3 }
+          - { python: "3.12", numpy: 1.26.4 }
         
     steps:
     - name: Get number of CPU cores
@@ -26,63 +32,46 @@ jobs:
 
     - uses: actions/checkout@v4
 
-    - name: Setup Python ${{ matrix.python-version }}
-      if: ${{ (matrix.os != 'macos-14') || ((matrix.os == 'macos-14') && (matrix.python-version != '3.8') && (matrix.python-version != '3.9')) }}
+    - name: Setup Python ${{ matrix.versions.python }}
+      if: ${{ (matrix.os != 'macos-14') || ((matrix.os == 'macos-14') && (matrix.versions.python != '3.8') && (matrix.versions.python != '3.9')) }}
       uses: actions/setup-python@v5
       id: pysetup
       with:
-        python-version: ${{ matrix.python-version }}
+        python-version: ${{ matrix.versions.python }}
         cache: 'pip'
 
     - name: Setup Python 3.8-3.9 - macos-arm
-      if: ${{ (matrix.os == 'macos-14') && ((matrix.python-version == '3.8') || (matrix.python-version == '3.9')) }}
+      if: ${{ (matrix.os == 'macos-14') && ((matrix.versions.python == '3.8') || (matrix.versions.python == '3.9')) }}
       run: |
         brew update
-        brew install python@${{ matrix.python-version }}
+        brew install python@${{ matrix.versions.python }}
         curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
-        python${{ matrix.python-version }} get-pip.py
+        python${{ matrix.versions.python }} get-pip.py
 
     - name: Create Python alias for Windows 
       if: matrix.os == 'windows-latest'
       run: |
-        $newPath = "${{ steps.pysetup.outputs.python-path }}".Replace("python.exe", "python${{ matrix.python-version }}.exe")
+        $newPath = "${{ steps.pysetup.outputs.python-path }}".Replace("python.exe", "python${{ matrix.versions.python }}.exe")
         New-Item -ItemType HardLink -Path "$newPath" -Value "${{ steps.pysetup.outputs.python-path }}"
 
     - name: Display Python and Pip versions
       run: | 
-        python${{ matrix.python-version }} -c "import sys; print(sys.version)"
+        python${{ matrix.versions.python }} -c "import sys; print(sys.version)"
         pip --version
 
     - name: Upgrade pip wheel setuptools
       run: pip install wheel setuptools pip --upgrade
 
-    - name: Install numpy for Python 3.8
-      if: matrix.python-version == '3.8'
-      run: pip install numpy==1.22.4
-        
-    - name: Install numpy for Python 3.9
-      if: matrix.python-version == '3.9'
-      run: pip install numpy==1.22.4
-
-    - name: Install numpy for Python 3.10
-      if: matrix.python-version == '3.10'
-      run: pip install numpy==1.22.4
-
-    - name: Install numpy for Python 3.11
-      if: matrix.python-version == '3.11'
-      run: pip install numpy==1.24.3
-
-    - name: Install numpy for Python 3.12
-      if: matrix.python-version == '3.12'
-      run: pip install numpy==1.26.4
+    - name: Install numpy ${{ matrix.versions.numpy }}
+      run: pip install numpy==${{ matrix.versions.numpy }}
     
     - name: Display numpy version
-      run: python${{ matrix.python-version }} -c "import numpy; print(numpy.__version__)"
+      run: python${{ matrix.versions.python }} -c "import numpy; print(numpy.__version__)"
 
     - name: Install other dependencies
       run: |
         pip install scipy Cython pytest pytest-cov flake8
-        python${{ matrix.python-version }} setup.py build_ext -j${{ steps.cpu-cores.outputs.count }}
+        python${{ matrix.versions.python }} setup.py build_ext -j${{ steps.cpu-cores.outputs.count }}
         pip install -e .[tests]
 
     - name: Lint with flake8

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -17,78 +17,53 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # Window 64 bit
+          # Windows 64 bit
           - os: windows-latest
             python-version: '3.8'
-            platform_id: win_amd64
           - os: windows-latest
             python-version: '3.9'
-            platform_id: win_amd64
           - os: windows-latest
             python-version: '3.10'
-            platform_id: win_amd64
           - os: windows-latest
             python-version: '3.11'
-            platform_id: win_amd64
           - os: windows-latest
             python-version: '3.12'
-            platform_id: win_amd64
 
-          # Linux 64 bit manylinux2014
+          # Linux 64 bit
           - os: ubuntu-latest
             python-version: '3.8'
-            platform_id: manylinux_x86_64
-            manylinux_image: manylinux2014
           - os: ubuntu-latest
             python-version: '3.9'
-            platform_id: manylinux_x86_64
-            manylinux_image: manylinux2014
           - os: ubuntu-latest
             python-version: '3.10'
-            platform_id: manylinux_x86_64
-            manylinux_image: manylinux2014
           - os: ubuntu-latest
             python-version: '3.11'
-            platform_id: manylinux_x86_64
-            manylinux_image: manylinux2014
           - os: ubuntu-latest
             python-version: '3.12'
-            platform_id: manylinux_x86_64
-            manylinux_image: manylinux2014
 
           # MacOS x86_64
-          - os: macos-latest
+          - os: macos-13
             python-version: '3.8'
-            platform_id: macosx_x86_64
-          - os: macos-latest
+          - os: macos-13
             python-version: '3.9'
-            platform_id: macosx_x86_64
-          - os: macos-latest
+          - os: macos-13
             python-version: '3.10'
-            platform_id: macosx_x86_64
-          - os: macos-latest
+          - os: macos-13
             python-version: '3.11'
-            platform_id: macosx_x86_64
-          - os: macos-latest
+          - os: macos-13
             python-version: '3.12'
-            platform_id: macosx_x86_64
 
           # MacOS arm64
-          - os: macos-12
+          - os: macos-14
             python-version: '3.8'
-            platform_id: macosx_arm64
-          - os: macos-12
+          - os: macos-14
             python-version: '3.9'
-            platform_id: macosx_arm64
           - os: macos-14
             python-version: '3.10'
-            platform_id: macosx_arm64
           - os: macos-14
             python-version: '3.11'
-            platform_id: macosx_arm64
           - os: macos-14
             python-version: '3.12'
-            platform_id: macosx_arm64
 
     steps:
     - name: Get number of CPU cores

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-latest]
+        os: [windows-latest, ubuntu-latest, macos-13, macos-14]
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
         
     steps:

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -18,52 +18,52 @@ jobs:
       matrix:
         include:
           # Windows 64 bit
-          # - os: windows-latest
-          #   python-version: '3.8'
-          # - os: windows-latest
-          #   python-version: '3.9'
-          # - os: windows-latest
-          #   python-version: '3.10'
-          # - os: windows-latest
-          #   python-version: '3.11'
-          # - os: windows-latest
-          #   python-version: '3.12'
+          - os: windows-latest
+            python-version: '3.8'
+          - os: windows-latest
+            python-version: '3.9'
+          - os: windows-latest
+            python-version: '3.10'
+          - os: windows-latest
+            python-version: '3.11'
+          - os: windows-latest
+            python-version: '3.12'
 
           # Linux 64 bit
-          # - os: ubuntu-latest
-          #   python-version: '3.8'
-          # - os: ubuntu-latest
-          #   python-version: '3.9'
-          # - os: ubuntu-latest
-          #   python-version: '3.10'
-          # - os: ubuntu-latest
-          #   python-version: '3.11'
-          # - os: ubuntu-latest
-          #   python-version: '3.12'
+          - os: ubuntu-latest
+            python-version: '3.8'
+          - os: ubuntu-latest
+            python-version: '3.9'
+          - os: ubuntu-latest
+            python-version: '3.10'
+          - os: ubuntu-latest
+            python-version: '3.11'
+          - os: ubuntu-latest
+            python-version: '3.12'
 
           # MacOS x86_64
-          # - os: macos-13
-          #   python-version: '3.8'
-          # - os: macos-13
-          #   python-version: '3.9'
-          # - os: macos-13
-          #   python-version: '3.10'
-          # - os: macos-13
-          #   python-version: '3.11'
-          # - os: macos-13
-          #   python-version: '3.12'
+          - os: macos-13
+            python-version: '3.8'
+          - os: macos-13
+            python-version: '3.9'
+          - os: macos-13
+            python-version: '3.10'
+          - os: macos-13
+            python-version: '3.11'
+          - os: macos-13
+            python-version: '3.12'
 
           # MacOS arm64
+          # - os: macos-14
+          #   python-version: '3.8.18'
+          # - os: macos-14
+          #   python-version: '3.9.19'
           - os: macos-14
-            python-version: '3.8.18'
+            python-version: '3.10'
           - os: macos-14
-            python-version: '3.9.19'
-          # - os: macos-14
-          #   python-version: '3.10'
-          # - os: macos-14
-          #   python-version: '3.11'
-          # - os: macos-14
-          #   python-version: '3.12'
+            python-version: '3.11'
+          - os: macos-14
+            python-version: '3.12'
 
     steps:
     - name: Get number of CPU cores
@@ -71,20 +71,6 @@ jobs:
       id: cpu-cores
 
     - uses: actions/checkout@v4
-    
-    # - name: Setup Python ${{ matrix.python-version }} - ${{ matrix.os }} 
-    #   if: ${{ (matrix.os != 'macos-14') || ((matrix.os == 'macos-14') && (matrix.python-version != '3.8') && (matrix.python-version != '3.9')) }}
-    #   uses: actions/setup-python@v5
-    #   with:
-    #     python-version: ${{ matrix.python-version }}
-    #     cache: 'pip'
-
-    # - name: Setup Python 3.8-3.9 - macos-arm 
-    #   if: ${{ (matrix.os == 'macos-14') && ((matrix.python-version == '3.8') || (matrix.python-version == '3.9')) }}
-    #   run: |
-    #     brew update
-    #     brew uninstall --ignore-dependencies python3
-    #     brew install python@${{ matrix.python-version }}
 
     - name: Setup Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -90,7 +90,6 @@ jobs:
             python: 312
             platform_id: macosx_arm64
 
-
     steps:
     - uses: actions/checkout@v2
     
@@ -107,19 +106,23 @@ jobs:
       run: python -m pip install wheel setuptools pip --upgrade
 
     - name: Install numpy for Python 3.8
-      if: matrix.python-version == '3.8'
+      if: matrix.python == '38'
       run: python -m pip install numpy==1.20.3
         
     - name: Install numpy for Python 3.9
-      if: matrix.python-version == '3.9'
+      if: matrix.python == '39'
       run: python -m pip install numpy==1.20.3
 
     - name: Install numpy for Python 3.10
-      if: matrix.python-version == '3.10'
+      if: matrix.python == '310'
       run: python -m pip install numpy==1.22.4
 
     - name: Install numpy for Python 3.11
-      if: matrix.python-version == '3.11'
+      if: matrix.python == '311'
+      run: python -m pip install numpy==1.24.3
+
+    - name: Install numpy for Python 3.12
+      if: matrix.python == '312'
       run: python -m pip install numpy==1.24.3
 
     - name: Display numpy version

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -54,9 +54,9 @@ jobs:
           #   python-version: '3.12'
 
           # MacOS arm64
-          - os: macos-14
+          - os: macos-11_arm64
             python-version: '3.8'
-          - os: macos-14
+          - os: macos-11_arm64
             python-version: '3.9'
           # - os: macos-14
           #   python-version: '3.10'
@@ -86,10 +86,10 @@ jobs:
     #     brew uninstall --ignore-dependencies python3
     #     brew install python@${{ matrix.python-version }}
 
-    - name: Setup Python
+    - name: Setup Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5
       with:
-        python-versions: ${{ matrix.python-version }}
+        python-version: ${{ matrix.python-version }}
         cache: 'pip'
 
     - name: Display Python version

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -86,7 +86,7 @@ jobs:
         brew install python@${{ matrix.python-version }}
         # curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
         # python${{ matrix.python-version }} get-pip.py
-        alias python=python${{ matrix.python-version }}
+        export PATH=$(brew --prefix python@${{ matrix.python-version }})/libexec/bin:$PATH
 
     - name: Display Python version
       run: python -c "import sys; print(sys.version)"

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -16,54 +16,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-          # Windows 64 bit
-          - os: windows-latest
-            python-version: '3.8'
-          - os: windows-latest
-            python-version: '3.9'
-          - os: windows-latest
-            python-version: '3.10'
-          - os: windows-latest
-            python-version: '3.11'
-          - os: windows-latest
-            python-version: '3.12'
-
-          # Linux 64 bit
-          - os: ubuntu-latest
-            python-version: '3.8'
-          - os: ubuntu-latest
-            python-version: '3.9'
-          - os: ubuntu-latest
-            python-version: '3.10'
-          - os: ubuntu-latest
-            python-version: '3.11'
-          - os: ubuntu-latest
-            python-version: '3.12'
-
-          # MacOS x86_64
-          - os: macos-13
-            python-version: '3.8'
-          - os: macos-13
-            python-version: '3.9'
-          - os: macos-13
-            python-version: '3.10'
-          - os: macos-13
-            python-version: '3.11'
-          - os: macos-13
-            python-version: '3.12'
-
-          # MacOS arm64
-          # - os: macos-14
-          #   python-version: '3.8.18'
-          # - os: macos-14
-          #   python-version: '3.9.19'
+        os: [windows-latest, ubuntu-latest, macos-13, macos-14]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        exclude:
           - os: macos-14
-            python-version: '3.10'
+            python-version: "3.8"
           - os: macos-14
-            python-version: '3.11'
-          - os: macos-14
-            python-version: '3.12'
+            python-version: "3.9"
 
     steps:
     - name: Get number of CPU cores

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -72,15 +72,15 @@ jobs:
 
     - uses: actions/checkout@v2
     
-    - name: Setup Python ${{ matrix.os }} - ${{ matrix.python-version }}
-      if: ${{ (matrix.os != 'macos-14') && (matrix.python-version != '3.8') && (matrix.python-version != '3.9') }}
+    - name: Setup Python ${{ matrix.python-version }} - ${{ matrix.os }} 
+      if: ${{ (matrix.os != 'macos-14') || ((matrix.os == 'macos-14') && (matrix.python-version != '3.8') && (matrix.python-version != '3.9')) }}
       uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
         cache: 'pip'
 
-    - name: Setup Python and pip for macos-arm - Python 3.8-3.9
-      if: ${{ (matrix.os == 'macos-14') && ((matrix.python-version == '3.8') || (matrix.python-version != '3.9')) }}
+    - name: Setup Python 3.8-3.9 - macos-arm 
+      if: ${{ (matrix.os == 'macos-14') && ((matrix.python-version == '3.8') || (matrix.python-version == '3.9')) }}
       run: |
         brew update
         brew install python@${{ matrix.python-version }}

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -91,6 +91,10 @@ jobs:
             platform_id: macosx_arm64
 
     steps:
+    - name: Get number of CPU cores
+      uses: SimenB/github-actions-cpu-cores@v2
+      id: cpu-cores
+
     - uses: actions/checkout@v2
     
     - name: Setup Python ${{ matrix.python-version }}
@@ -131,6 +135,7 @@ jobs:
     - name: Install other dependencies
       run: |
         python -m pip install scipy Cython pytest pytest-cov flake8
+        python setup.py build_ext -j${{ steps.cpu-cores.outputs.count }}
         python -m pip install -e .[tests]
 
     - name: Lint with flake8

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -74,10 +74,10 @@ jobs:
             platform_id: macosx_x86_64
 
           # MacOS arm64
-          - os: macos-14
+          - os: macos-12
             python-version: '3.8'
             platform_id: macosx_arm64
-          - os: macos-14
+          - os: macos-12
             python-version: '3.9'
             platform_id: macosx_arm64
           - os: macos-14

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -54,10 +54,10 @@ jobs:
           #   python-version: '3.12'
 
           # MacOS arm64
-          - os: macos-11_arm64
-            python-version: '3.8'
-          - os: macos-11_arm64
-            python-version: '3.9'
+          - os: macos-14
+            python-version: '3.8.18'
+          - os: macos-14
+            python-version: '3.9.19'
           # - os: macos-14
           #   python-version: '3.10'
           # - os: macos-14
@@ -70,7 +70,7 @@ jobs:
       uses: SimenB/github-actions-cpu-cores@v2
       id: cpu-cores
 
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     
     # - name: Setup Python ${{ matrix.python-version }} - ${{ matrix.os }} 
     #   if: ${{ (matrix.os != 'macos-14') || ((matrix.os == 'macos-14') && (matrix.python-version != '3.8') && (matrix.python-version != '3.9')) }}
@@ -87,7 +87,7 @@ jobs:
     #     brew install python@${{ matrix.python-version }}
 
     - name: Setup Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
         cache: 'pip'

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -70,7 +70,7 @@ jobs:
       uses: SimenB/github-actions-cpu-cores@v2
       id: cpu-cores
 
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v3
     
     # - name: Setup Python ${{ matrix.python-version }} - ${{ matrix.os }} 
     #   if: ${{ (matrix.os != 'macos-14') || ((matrix.os == 'macos-14') && (matrix.python-version != '3.8') && (matrix.python-version != '3.9')) }}
@@ -87,7 +87,7 @@ jobs:
     #     brew install python@${{ matrix.python-version }}
 
     - name: Setup Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
         cache: 'pip'

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -45,7 +45,7 @@ jobs:
     - name: Create Python alias for Windows 
       if: matrix.os == 'windows-latest'
       run: |
-        $newPath = ${{ steps.pysetup.outputs.python-path }} -replace "python.exe", "python${{ matrix.python-version }}.exe"
+        $newPath = "${{ steps.pysetup.outputs.python-path }}".Replace("python.exe", "python${{ matrix.python-version }}.exe")
         mklink "$newPath" "${{ steps.pysetup.outputs.python-path }}"
 
     - name: Display Python and Pip versions

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -28,6 +28,10 @@ jobs:
             python-version: "3.8"
           - os: macos-14
             python-version: "3.9"
+          - os: macos-14
+            python-version: "3.10"
+          - os: macos-13
+            python-version: "3.10"
 
     steps:
     - name: Get number of CPU cores
@@ -80,12 +84,12 @@ jobs:
       run: pip install numpy==1.26.4
     
     - name: Display numpy version
-      run: python -c "import numpy; print(numpy.__version__)"
+      run: python${{ matrix.python-version }} -c "import numpy; print(numpy.__version__)"
 
     - name: Install other dependencies
       run: |
         pip install scipy Cython pytest pytest-cov flake8
-        python setup.py build_ext -j${{ steps.cpu-cores.outputs.count }}
+        python${{ matrix.python-version }} setup.py build_ext -j${{ steps.cpu-cores.outputs.count }}
         pip install -e .[tests]
 
     - name: Lint with flake8

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -70,21 +70,27 @@ jobs:
       uses: SimenB/github-actions-cpu-cores@v2
       id: cpu-cores
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     
-    - name: Setup Python ${{ matrix.python-version }} - ${{ matrix.os }} 
-      if: ${{ (matrix.os != 'macos-14') || ((matrix.os == 'macos-14') && (matrix.python-version != '3.8') && (matrix.python-version != '3.9')) }}
-      uses: actions/setup-python@v5
+    # - name: Setup Python ${{ matrix.python-version }} - ${{ matrix.os }} 
+    #   if: ${{ (matrix.os != 'macos-14') || ((matrix.os == 'macos-14') && (matrix.python-version != '3.8') && (matrix.python-version != '3.9')) }}
+    #   uses: actions/setup-python@v5
+    #   with:
+    #     python-version: ${{ matrix.python-version }}
+    #     cache: 'pip'
+
+    # - name: Setup Python 3.8-3.9 - macos-arm 
+    #   if: ${{ (matrix.os == 'macos-14') && ((matrix.python-version == '3.8') || (matrix.python-version == '3.9')) }}
+    #   run: |
+    #     brew update
+    #     brew uninstall --ignore-dependencies python3
+    #     brew install python@${{ matrix.python-version }}
+
+    - name: Setup Python
+      uses: actions/python-version@v3
       with:
         python-version: ${{ matrix.python-version }}
         cache: 'pip'
-
-    - name: Setup Python 3.8-3.9 - macos-arm 
-      if: ${{ (matrix.os == 'macos-14') && ((matrix.python-version == '3.8') || (matrix.python-version == '3.9')) }}
-      run: |
-        brew update
-        brew uninstall --ignore-dependencies python3
-        brew install python@${{ matrix.python-version }}
 
     - name: Display Python version
       run: python -c "import sys; print(sys.version)"

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -70,15 +70,11 @@ jobs:
 
     - name: Install numpy for Pypy 3.8 arm64
       if: matrix.python-version == 'pypy3.8'
-      run: |
-          sudo apt-get install -y pypy-dev
-          pypy -m pip install numpy==1.20.3
+      run: python -m pip install numpy==1.20.3
         
     - name: Install numpy for Pypy 3.9 arm64
       if: matrix.python-version == 'pypy3.9'
-      run: |
-          sudo apt-gey install -y pypy-dev
-          pypy -m pip install numpy==1.20.3
+      run: python -m pip install numpy==1.20.3
     
     - name: Display numpy version
       run: python -c "import numpy; print(numpy.__version__)"

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -44,7 +44,7 @@ jobs:
 
     - name: Create Python alias for Windows 
       if: matrix.os == 'windows-latest'
-      run: New-Alias -Name "python${{ matrix.python-version }}" python
+      run: mklink "${{ steps.pysetup.outputs.python-path }}\python.exe" "${{ steps.pysetup.outputs.python-path }}\python${{ matrix.python-version }}.exe"
 
     - name: Display Python and Pip versions
       run: | 

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -86,6 +86,7 @@ jobs:
         brew install python@${{ matrix.python-version }}
         curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
         python${{ matrix.python-version }} get-pip.py
+        brew unlink python && brew link python
 
     - name: Display Python version
       run: python -c "import sys; print(sys.version)"

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -84,9 +84,9 @@ jobs:
       run: |
         brew update
         brew install python@${{ matrix.python-version }}
-        curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
-        python${{ matrix.python-version }} get-pip.py
-        brew unlink python && brew link python@${{ matrix.python-version }}
+        # curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
+        # python${{ matrix.python-version }} get-pip.py
+        alias python=python${{ matrix.python-version }}
 
     - name: Display Python version
       run: python -c "import sys; print(sys.version)"

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -16,8 +16,80 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, macos-latest, windows-latest]
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        include:
+          # Window 64 bit
+          - os: windows-latest
+            python: 38
+            platform_id: win_amd64
+          - os: windows-latest
+            python: 39
+            platform_id: win_amd64
+          - os: windows-latest
+            python: 310
+            platform_id: win_amd64
+          - os: windows-latest
+            python: 311
+            platform_id: win_amd64
+          - os: windows-latest
+            python: 312
+            platform_id: win_amd64
+
+          # Linux 64 bit manylinux2014
+          - os: ubuntu-latest
+            python: 38
+            platform_id: manylinux_x86_64
+            manylinux_image: manylinux2014
+          - os: ubuntu-latest
+            python: 39
+            platform_id: manylinux_x86_64
+            manylinux_image: manylinux2014
+          - os: ubuntu-latest
+            python: 310
+            platform_id: manylinux_x86_64
+            manylinux_image: manylinux2014
+          - os: ubuntu-latest
+            python: 311
+            platform_id: manylinux_x86_64
+            manylinux_image: manylinux2014
+          - os: ubuntu-latest
+            python: 312
+            platform_id: manylinux_x86_64
+            manylinux_image: manylinux2014
+
+          # MacOS x86_64
+          - os: macos-latest
+            python: 38
+            platform_id: macosx_x86_64
+          - os: macos-latest
+            python: 39
+            platform_id: macosx_x86_64
+          - os: macos-latest
+            python: 310
+            platform_id: macosx_x86_64
+          - os: macos-latest
+            python: 311
+            platform_id: macosx_x86_64
+          - os: macos-latest
+            python: 312
+            platform_id: macosx_x86_64
+
+          # MacOS arm64
+          - os: macos-14
+            python: 38
+            platform_id: macosx_arm64
+          - os: macos-14
+            python: 39
+            platform_id: macosx_arm64
+          - os: macos-14
+            python: 310
+            platform_id: macosx_arm64
+          - os: macos-14
+            python: 311
+            platform_id: macosx_arm64
+          - os: macos-14
+            python: 312
+            platform_id: macosx_arm64
+
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -18,52 +18,52 @@ jobs:
       matrix:
         include:
           # Windows 64 bit
-          - os: windows-latest
-            python-version: '3.8'
-          - os: windows-latest
-            python-version: '3.9'
-          - os: windows-latest
-            python-version: '3.10'
-          - os: windows-latest
-            python-version: '3.11'
-          - os: windows-latest
-            python-version: '3.12'
+          # - os: windows-latest
+          #   python-version: '3.8'
+          # - os: windows-latest
+          #   python-version: '3.9'
+          # - os: windows-latest
+          #   python-version: '3.10'
+          # - os: windows-latest
+          #   python-version: '3.11'
+          # - os: windows-latest
+          #   python-version: '3.12'
 
           # Linux 64 bit
-          - os: ubuntu-latest
-            python-version: '3.8'
-          - os: ubuntu-latest
-            python-version: '3.9'
-          - os: ubuntu-latest
-            python-version: '3.10'
-          - os: ubuntu-latest
-            python-version: '3.11'
-          - os: ubuntu-latest
-            python-version: '3.12'
+          # - os: ubuntu-latest
+          #   python-version: '3.8'
+          # - os: ubuntu-latest
+          #   python-version: '3.9'
+          # - os: ubuntu-latest
+          #   python-version: '3.10'
+          # - os: ubuntu-latest
+          #   python-version: '3.11'
+          # - os: ubuntu-latest
+          #   python-version: '3.12'
 
           # MacOS x86_64
-          - os: macos-13
-            python-version: '3.8'
-          - os: macos-13
-            python-version: '3.9'
-          - os: macos-13
-            python-version: '3.10'
-          - os: macos-13
-            python-version: '3.11'
-          - os: macos-13
-            python-version: '3.12'
+          # - os: macos-13
+          #   python-version: '3.8'
+          # - os: macos-13
+          #   python-version: '3.9'
+          # - os: macos-13
+          #   python-version: '3.10'
+          # - os: macos-13
+          #   python-version: '3.11'
+          # - os: macos-13
+          #   python-version: '3.12'
 
           # MacOS arm64
           - os: macos-14
             python-version: '3.8'
           - os: macos-14
             python-version: '3.9'
-          - os: macos-14
-            python-version: '3.10'
-          - os: macos-14
-            python-version: '3.11'
-          - os: macos-14
-            python-version: '3.12'
+          # - os: macos-14
+          #   python-version: '3.10'
+          # - os: macos-14
+          #   python-version: '3.11'
+          # - os: macos-14
+          #   python-version: '3.12'
 
     steps:
     - name: Get number of CPU cores
@@ -86,7 +86,7 @@ jobs:
         brew install python@${{ matrix.python-version }}
         curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
         python${{ matrix.python-version }} get-pip.py
-        brew unlink python && brew link python
+        brew unlink python && brew link python@${{ matrix.python-version }}
 
     - name: Display Python version
       run: python -c "import sys; print(sys.version)"

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -46,7 +46,7 @@ jobs:
       if: matrix.os == 'windows-latest'
       run: |
         $newPath = "${{ steps.pysetup.outputs.python-path }}".Replace("python.exe", "python${{ matrix.python-version }}.exe")
-        mklink "$newPath" "${{ steps.pysetup.outputs.python-path }}"
+        New-Item -ItemType HardLink -Path "$newPath" -Value "${{ steps.pysetup.outputs.python-path }}"
 
     - name: Display Python and Pip versions
       run: | 

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -70,11 +70,15 @@ jobs:
 
     - name: Install numpy for Pypy 3.8 arm64
       if: matrix.python-version == 'pypy3.8'
-      run: pypy -m pip install numpy==1.20.3
+      run: |
+          sudo apt-get install -y pypy-dev
+          pypy -m pip install numpy==1.20.3
         
     - name: Install numpy for Pypy 3.9 arm64
       if: matrix.python-version == 'pypy3.9'
-      run: pypy -m pip install numpy==1.20.3
+      run: |
+          sudo apt-gey install -y pypy-dev
+          pypy -m pip install numpy==1.20.3
     
     - name: Display numpy version
       run: python -c "import numpy; print(numpy.__version__)"

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -68,6 +68,14 @@ jobs:
       if: matrix.python-version == '3.12'
       run: python -m pip install numpy==1.26.4
 
+    - name: Install numpy for Pypy 3.8 arm64
+      if: matrix.python-version == 'pypy3.8'
+      run: pypy -m pip install numpy==1.20.3
+        
+    - name: Install numpy for Pypy 3.9 arm64
+      if: matrix.python-version == 'pypy3.9'
+      run: pypy -m pip install numpy==1.20.3
+    
     - name: Display numpy version
       run: python -c "import numpy; print(numpy.__version__)"
 

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -44,7 +44,7 @@ jobs:
 
     - name: Create Python alias for Windows 
       if: matrix.os == 'windows-latest'
-      run: mklink "${{ steps.pysetup.outputs.python-path }}\python.exe" "${{ steps.pysetup.outputs.python-path }}\python${{ matrix.python-version }}.exe"
+      run: Set-Alias -Name python${{ matrix.python-version }} -Value ${{ steps.pysetup.outputs.python-path }}
 
     - name: Display Python and Pip versions
       run: | 

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -87,9 +87,9 @@ jobs:
     #     brew install python@${{ matrix.python-version }}
 
     - name: Setup Python
-      uses: actions/python-versions@v3
+      uses: actions/setup-python@v5
       with:
-        python-version: ${{ matrix.python-version }}
+        python-versions: ${{ matrix.python-version }}
         cache: 'pip'
 
     - name: Display Python version

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -19,82 +19,82 @@ jobs:
         include:
           # Window 64 bit
           - os: windows-latest
-            python: 38
+            python-version: '3.8'
             platform_id: win_amd64
           - os: windows-latest
-            python: 39
+            python-version: '3.9'
             platform_id: win_amd64
           - os: windows-latest
-            python: 310
+            python-version: '3.10'
             platform_id: win_amd64
           - os: windows-latest
-            python: 311
+            python-version: '3.11'
             platform_id: win_amd64
           - os: windows-latest
-            python: 312
+            python-version: '3.12'
             platform_id: win_amd64
 
           # Linux 64 bit manylinux2014
           - os: ubuntu-latest
-            python: 38
+            python-version: '3.8'
             platform_id: manylinux_x86_64
             manylinux_image: manylinux2014
           - os: ubuntu-latest
-            python: 39
+            python-version: '3.9'
             platform_id: manylinux_x86_64
             manylinux_image: manylinux2014
           - os: ubuntu-latest
-            python: 310
+            python-version: '3.10'
             platform_id: manylinux_x86_64
             manylinux_image: manylinux2014
           - os: ubuntu-latest
-            python: 311
+            python-version: '3.11'
             platform_id: manylinux_x86_64
             manylinux_image: manylinux2014
           - os: ubuntu-latest
-            python: 312
+            python-version: '3.12'
             platform_id: manylinux_x86_64
             manylinux_image: manylinux2014
 
           # MacOS x86_64
           - os: macos-latest
-            python: 38
+            python-version: '3.8'
             platform_id: macosx_x86_64
           - os: macos-latest
-            python: 39
+            python-version: '3.9'
             platform_id: macosx_x86_64
           - os: macos-latest
-            python: 310
+            python-version: '3.10'
             platform_id: macosx_x86_64
           - os: macos-latest
-            python: 311
+            python-version: '3.11'
             platform_id: macosx_x86_64
           - os: macos-latest
-            python: 312
+            python-version: '3.12'
             platform_id: macosx_x86_64
 
           # MacOS arm64
           - os: macos-14
-            python: 38
+            python-version: '3.8'
             platform_id: macosx_arm64
           - os: macos-14
-            python: 39
+            python-version: '3.9'
             platform_id: macosx_arm64
           - os: macos-14
-            python: 310
+            python-version: '3.10'
             platform_id: macosx_arm64
           - os: macos-14
-            python: 311
+            python-version: '3.11'
             platform_id: macosx_arm64
           - os: macos-14
-            python: 312
+            python-version: '3.12'
             platform_id: macosx_arm64
 
     steps:
     - uses: actions/checkout@v2
     
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+    - name: Setup Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
         cache: 'pip'
@@ -106,23 +106,23 @@ jobs:
       run: python -m pip install wheel setuptools pip --upgrade
 
     - name: Install numpy for Python 3.8
-      if: matrix.python == '38'
+      if: matrix.python-version == '3.8'
       run: python -m pip install numpy==1.20.3
         
     - name: Install numpy for Python 3.9
-      if: matrix.python == '39'
+      if: matrix.python-version == '3.9'
       run: python -m pip install numpy==1.20.3
 
     - name: Install numpy for Python 3.10
-      if: matrix.python == '310'
+      if: matrix.python-version == '3.10'
       run: python -m pip install numpy==1.22.4
 
     - name: Install numpy for Python 3.11
-      if: matrix.python == '311'
+      if: matrix.python-version == '3.11'
       run: python -m pip install numpy==1.24.3
 
     - name: Install numpy for Python 3.12
-      if: matrix.python == '312'
+      if: matrix.python-version == '3.12'
       run: python -m pip install numpy==1.24.3
 
     - name: Display numpy version

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -23,6 +23,11 @@ jobs:
             python-version: "3.8"
           - os: macos-14
             python-version: "3.9"
+        include:
+          - os: macos-14
+            python-version: "pypy3.8"
+          - os: macos-14
+            python-version: "pypy3.9"
 
     steps:
     - name: Get number of CPU cores

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -19,20 +19,95 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, macos-latest, windows-latest]
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
-        
+        include:
+          # Window 64 bit
+          - os: windows-latest
+            python-version: '3.8'
+            platform_id: win_amd64
+          - os: windows-latest
+            python-version: '3.9'
+            platform_id: win_amd64
+          - os: windows-latest
+            python-version: '3.10'
+            platform_id: win_amd64
+          - os: windows-latest
+            python-version: '3.11'
+            platform_id: win_amd64
+          - os: windows-latest
+            python-version: '3.12'
+            platform_id: win_amd64
+
+          # Linux 64 bit manylinux2014
+          - os: ubuntu-latest
+            python-version: '3.8'
+            platform_id: manylinux_x86_64
+            manylinux_image: manylinux2014
+          - os: ubuntu-latest
+            python-version: '3.9'
+            platform_id: manylinux_x86_64
+            manylinux_image: manylinux2014
+          - os: ubuntu-latest
+            python-version: '3.10'
+            platform_id: manylinux_x86_64
+            manylinux_image: manylinux2014
+          - os: ubuntu-latest
+            python-version: '3.11'
+            platform_id: manylinux_x86_64
+            manylinux_image: manylinux2014
+          - os: ubuntu-latest
+            python-version: '3.12'
+            platform_id: manylinux_x86_64
+            manylinux_image: manylinux2014
+
+          # MacOS x86_64
+          - os: macos-latest
+            python-version: '3.8'
+            platform_id: macosx_x86_64
+          - os: macos-latest
+            python-version: '3.9'
+            platform_id: macosx_x86_64
+          - os: macos-latest
+            python-version: '3.10'
+            platform_id: macosx_x86_64
+          - os: macos-latest
+            python-version: '3.11'
+            platform_id: macosx_x86_64
+          - os: macos-latest
+            python-version: '3.12'
+            platform_id: macosx_x86_64
+
+          # MacOS arm64
+          - os: macos-12
+            python-version: '3.8'
+            platform_id: macosx_arm64
+          - os: macos-12
+            python-version: '3.9'
+            platform_id: macosx_arm64
+          - os: macos-14
+            python-version: '3.10'
+            platform_id: macosx_arm64
+          - os: macos-14
+            python-version: '3.11'
+            platform_id: macosx_arm64
+          - os: macos-14
+            python-version: '3.12'
+            platform_id: macosx_arm64
+
     steps:
     - uses: actions/checkout@v2
-
-    - name: Set up Python
-      uses: actions/setup-python@v2
+    
+    - name: Setup Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
+        cache: 'pip'
 
     - name: Display Python version
       run: python -c "import sys; print(sys.version)"
-    
+
+    - name: Upgrade pip wheel setuptools
+      run: python -m pip install wheel setuptools pip --upgrade
+
     - name: Install numpy for Python 3.8
       if: matrix.python-version == '3.8'
       run: python -m pip install numpy==1.20.3
@@ -48,6 +123,10 @@ jobs:
     - name: Install numpy for Python 3.11
       if: matrix.python-version == '3.11'
       run: python -m pip install numpy==1.24.3
+
+    - name: Install numpy for Python 3.12
+      if: matrix.python-version == '3.12'
+      run: python -m pip install numpy==1.26.4
 
     - name: Display numpy version
       run: python -c "import numpy; print(numpy.__version__)"

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -28,6 +28,7 @@ jobs:
     - name: Setup Python ${{ matrix.python-version }}
       if: ${{ (matrix.os != 'macos-14') || ((matrix.os == 'macos-14') && (matrix.python-version != '3.8') && (matrix.python-version != '3.9')) }}
       uses: actions/setup-python@v5
+      id: pysetup
       with:
         python-version: ${{ matrix.python-version }}
         cache: 'pip'
@@ -39,6 +40,12 @@ jobs:
         brew install python@${{ matrix.python-version }}
         curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
         python${{ matrix.python-version }} get-pip.py
+
+    - name: Create Python alias for Windows 
+      if: matrix.os == 'windows-latest'
+      run: |
+        $newPath = "${{ steps.pysetup.outputs.python-path }}".Replace("python.exe", "python${{ matrix.python-version }}.exe")
+        New-Item -ItemType HardLink -Path "$newPath" -Value "${{ steps.pysetup.outputs.python-path }}"
 
     - name: Display Python and Pip versions
       run: | 

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -20,70 +20,58 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-latest, ubuntu-latest, macos-13, macos-14]
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        versions:
+          - { python: "3.8", numpy: 1.22.4 }
+          - { python: "3.9", numpy: 1.22.4 }
+          - { python: "3.10", numpy: 1.22.4 }
+          - { python: "3.11", numpy: 1.24.3 }
+          - { python: "3.12", numpy: 1.26.4 }
 
     steps:
     - uses: actions/checkout@v4
     
-    - name: Setup Python ${{ matrix.python-version }}
-      if: ${{ (matrix.os != 'macos-14') || ((matrix.os == 'macos-14') && (matrix.python-version != '3.8') && (matrix.python-version != '3.9')) }}
+    - name: Setup Python ${{ matrix.versions.python }}
+      if: ${{ (matrix.os != 'macos-14') || ((matrix.os == 'macos-14') && (matrix.versions.python != '3.8') && (matrix.versions.python != '3.9')) }}
       uses: actions/setup-python@v5
       id: pysetup
       with:
-        python-version: ${{ matrix.python-version }}
+        python-version: ${{ matrix.versions.python }}
         cache: 'pip'
 
     - name: Setup Python 3.8-3.9 - macos-arm
-      if: ${{ (matrix.os == 'macos-14') && ((matrix.python-version == '3.8') || (matrix.python-version == '3.9')) }}
+      if: ${{ (matrix.os == 'macos-14') && ((matrix.versions.python == '3.8') || (matrix.versions.python == '3.9')) }}
       run: |
         brew update
-        brew install python@${{ matrix.python-version }}
+        brew install python@${{ matrix.versions.python }}
         curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
-        python${{ matrix.python-version }} get-pip.py
+        python${{ matrix.versions.python }} get-pip.py
 
     - name: Create Python alias for Windows 
       if: matrix.os == 'windows-latest'
       run: |
-        $newPath = "${{ steps.pysetup.outputs.python-path }}".Replace("python.exe", "python${{ matrix.python-version }}.exe")
+        $newPath = "${{ steps.pysetup.outputs.python-path }}".Replace("python.exe", "python${{ matrix.versions.python }}.exe")
         New-Item -ItemType HardLink -Path "$newPath" -Value "${{ steps.pysetup.outputs.python-path }}"
 
     - name: Display Python and Pip versions
       run: | 
-        python${{ matrix.python-version }} -c "import sys; print(sys.version)"
+        python${{ matrix.versions.python }} -c "import sys; print(sys.version)"
         pip --version
 
     - name: Upgrade pip wheel setuptools
       run: pip install wheel setuptools pip --upgrade
 
-    - name: Install numpy for Python 3.8
-      if: matrix.python-version == '3.8'
-      run: pip install numpy==1.22.4
-        
-    - name: Install numpy for Python 3.9
-      if: matrix.python-version == '3.9'
-      run: pip install numpy==1.22.4
-
-    - name: Install numpy for Python 3.10
-      if: matrix.python-version == '3.10'
-      run: pip install numpy==1.22.4
-
-    - name: Install numpy for Python 3.11
-      if: matrix.python-version == '3.11'
-      run: pip install numpy==1.24.3
-
-    - name: Install numpy for Python 3.12
-      if: matrix.python-version == '3.12'
-      run: pip install numpy==1.26.4
+    - name: Install numpy ${{ matrix.versions.numpy }}
+      run: pip install numpy==${{ matrix.versions.numpy }}
     
     - name: Display numpy version
-      run: python${{ matrix.python-version }} -c "import numpy; print(numpy.__version__)"
+      run: python${{ matrix.versions.python }} -c "import numpy; print(numpy.__version__)"
 
     - name: Install other dependencies
       run: |
         pip install scipy Cython wheel
     
     - name: Build wheels
-      run: python${{ matrix.python-version }} setup.py bdist_wheel
+      run: python${{ matrix.versions.python }} setup.py bdist_wheel
         
     - name: Rename Linux wheels to supported platform of PyPI
       if: matrix.os == 'ubuntu-latest'

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -19,127 +19,67 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-          # Window 64 bit
-          - os: windows-latest
-            python-version: '3.8'
-            platform_id: win_amd64
-          - os: windows-latest
-            python-version: '3.9'
-            platform_id: win_amd64
-          - os: windows-latest
-            python-version: '3.10'
-            platform_id: win_amd64
-          - os: windows-latest
-            python-version: '3.11'
-            platform_id: win_amd64
-          - os: windows-latest
-            python-version: '3.12'
-            platform_id: win_amd64
-
-          # Linux 64 bit manylinux2014
-          - os: ubuntu-latest
-            python-version: '3.8'
-            platform_id: manylinux_x86_64
-            manylinux_image: manylinux2014
-          - os: ubuntu-latest
-            python-version: '3.9'
-            platform_id: manylinux_x86_64
-            manylinux_image: manylinux2014
-          - os: ubuntu-latest
-            python-version: '3.10'
-            platform_id: manylinux_x86_64
-            manylinux_image: manylinux2014
-          - os: ubuntu-latest
-            python-version: '3.11'
-            platform_id: manylinux_x86_64
-            manylinux_image: manylinux2014
-          - os: ubuntu-latest
-            python-version: '3.12'
-            platform_id: manylinux_x86_64
-            manylinux_image: manylinux2014
-
-          # MacOS x86_64
-          - os: macos-latest
-            python-version: '3.8'
-            platform_id: macosx_x86_64
-          - os: macos-latest
-            python-version: '3.9'
-            platform_id: macosx_x86_64
-          - os: macos-latest
-            python-version: '3.10'
-            platform_id: macosx_x86_64
-          - os: macos-latest
-            python-version: '3.11'
-            platform_id: macosx_x86_64
-          - os: macos-latest
-            python-version: '3.12'
-            platform_id: macosx_x86_64
-
-          # MacOS arm64
-          - os: macos-12
-            python-version: '3.8'
-            platform_id: macosx_arm64
-          - os: macos-12
-            python-version: '3.9'
-            platform_id: macosx_arm64
-          - os: macos-14
-            python-version: '3.10'
-            platform_id: macosx_arm64
-          - os: macos-14
-            python-version: '3.11'
-            platform_id: macosx_arm64
-          - os: macos-14
-            python-version: '3.12'
-            platform_id: macosx_arm64
+        os: [windows-latest, ubuntu-latest, macos-13, macos-14]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     
     - name: Setup Python ${{ matrix.python-version }}
+      if: ${{ (matrix.os != 'macos-14') || ((matrix.os == 'macos-14') && (matrix.python-version != '3.8') && (matrix.python-version != '3.9')) }}
       uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
         cache: 'pip'
 
-    - name: Display Python version
-      run: python -c "import sys; print(sys.version)"
+    - name: Setup Python 3.8-3.9 - macos-arm
+      if: ${{ (matrix.os == 'macos-14') && ((matrix.python-version == '3.8') || (matrix.python-version == '3.9')) }}
+      run: |
+        brew update
+        brew install python@${{ matrix.python-version }}
+        curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
+        python${{ matrix.python-version }} get-pip.py
+
+    - name: Display Python and Pip versions
+      run: | 
+        python${{ matrix.python-version }} -c "import sys; print(sys.version)"
+        pip --version
 
     - name: Upgrade pip wheel setuptools
-      run: python -m pip install wheel setuptools pip --upgrade
+      run: pip install wheel setuptools pip --upgrade
 
     - name: Install numpy for Python 3.8
       if: matrix.python-version == '3.8'
-      run: python -m pip install numpy==1.20.3
+      run: pip install numpy==1.22.4
         
     - name: Install numpy for Python 3.9
       if: matrix.python-version == '3.9'
-      run: python -m pip install numpy==1.20.3
+      run: pip install numpy==1.22.4
 
     - name: Install numpy for Python 3.10
       if: matrix.python-version == '3.10'
-      run: python -m pip install numpy==1.22.4
+      run: pip install numpy==1.22.4
 
     - name: Install numpy for Python 3.11
       if: matrix.python-version == '3.11'
-      run: python -m pip install numpy==1.24.3
+      run: pip install numpy==1.24.3
 
     - name: Install numpy for Python 3.12
       if: matrix.python-version == '3.12'
-      run: python -m pip install numpy==1.26.4
-
+      run: pip install numpy==1.26.4
+    
     - name: Display numpy version
-      run: python -c "import numpy; print(numpy.__version__)"
+      run: python${{ matrix.python-version }} -c "import numpy; print(numpy.__version__)"
 
     - name: Install other dependencies
       run: |
-        python -m pip install scipy Cython wheel
+        pip install scipy Cython wheel
     
     - name: Build wheels
-      run: python setup.py bdist_wheel
+      run: python${{ matrix.python-version }} setup.py bdist_wheel
         
     - name: Rename Linux wheels to supported platform of PyPI
-      if: matrix.os == 'ubuntu-20.04'
+      if: matrix.os == 'ubuntu-latest'
       run: for f in dist/*.whl; do mv "$f" "$(echo "$f" | sed s/linux/manylinux1/)"; done
 
     - name: Publish wheels to GitHub artifacts
@@ -151,9 +91,9 @@ jobs:
 
   publish-pypi:
     needs: [build-wheels]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
           
     - uses: actions/download-artifact@v2
       with:
@@ -161,7 +101,7 @@ jobs:
         path: dist/
 
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: "3.10"
 

--- a/setup.py
+++ b/setup.py
@@ -357,6 +357,7 @@ setup(
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
         "License :: OSI Approved :: Apache Software License",
         "Topic :: Software Development",
         "Topic :: Scientific/Engineering",


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
Currently we don't have actions to test and build binaries for MacOS arm64 platform (M chips). That's the main motivation for this update.

### Related Issues
<!--- If it fixes an open issue, please link to the issue here. -->


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have added tests.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated `README.md` (if you are adding a new model).
- [ ] I have updated `examples/README.md` (if you are adding a new example).
- [ ] I have updated `datasets/README.md` (if you are adding a new dataset).
