### PR TITLE
Fix EFM._build_matrices() method

### DIFF
--- a/cornac/models/efm/recom_efm.pyx
+++ b/cornac/models/efm/recom_efm.pyx
@@ -359,6 +359,10 @@ class EFM(Recommender):
             print('Optimization finished!')
 
     def _build_matrices(self, data_set):
+        self.num_users = data_set.num_users
+        self.num_items = data_set.num_items
+        self.num_aspects = data_set.sentiment.num_aspects
+
         sentiment = data_set.sentiment
         ratings = []
         map_uid = []


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
The two methods `knows_user` and `knows_item` check whether `uid` (or `iid`) is smaller than `self.num_users` (or `self.num_items`), which doesn't exist because `fit()` was never executed. 

This commit tries to fix an error in `recommender-systems` tutorial notebook 7, where `EFM.train_set` is assigned and `_build_matrices()` is executed before `fit()`:
```python
efm = EFM()
efm.train_set = rs.train_set
_, X, Y = efm._build_matrices(rs.train_set)
```