### PR TITLE
Update LightGCN to remove torch requirement for prediction

### DIFF
--- a/cornac/models/lightgcn/lightgcn.py
+++ b/cornac/models/lightgcn/lightgcn.py
@@ -62,11 +62,10 @@ class GCNLayer(nn.Module):
 
 
 class Model(nn.Module):
-    def __init__(self, g, in_size, num_layers, lambda_reg, device=None):
+    def __init__(self, g, in_size, num_layers, lambda_reg):
         super(Model, self).__init__()
         self.norm_dict = dict()
         self.lambda_reg = lambda_reg
-        self.device = device
 
         self.layers = nn.ModuleList([GCNLayer() for _ in range(num_layers)])
 

--- a/cornac/models/lightgcn/recom_lightgcn.py
+++ b/cornac/models/lightgcn/recom_lightgcn.py
@@ -124,21 +124,21 @@ class LightGCN(Recommender, ANNMixin):
         from .lightgcn import Model
         from .lightgcn import construct_graph
 
-        self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+        device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
         if self.seed is not None:
             torch.manual_seed(self.seed)
             if torch.cuda.is_available():
                 torch.cuda.manual_seed_all(self.seed)
 
         graph = construct_graph(train_set, self.total_users, self.total_items).to(
-            self.device
+            device
         )
         model = Model(
             graph,
             self.emb_size,
             self.num_layers,
             self.lambda_reg,
-        ).to(self.device)
+        ).to(device)
 
         optimizer = torch.optim.Adam(model.parameters(), lr=self.learning_rate)
 


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
This PR removes the need of `torch` dependency for prediction, as it uses numpy instead.
Declaring a `self.device` with cuda would lead to the attempt on loading torch on pickle load, which throws an error should it not be installed.


### Related Issues
<!--- If it fixes an open issue, please link to the issue here. -->


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have added tests.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated `README.md` (if you are adding a new model).
- [ ] I have updated `examples/README.md` (if you are adding a new example).
- [ ] I have updated `datasets/README.md` (if you are adding a new dataset).
