### PR TITLE
Fix Documentation iamaresearcher.rst Tuning Hyperparameters

### DIFF
--- a/docs/source/user/iamaresearcher.rst
+++ b/docs/source/user/iamaresearcher.rst
@@ -163,7 +163,7 @@ experiments using the ``cornac.Experiment`` class.
         ml_100k = cornac.datasets.movielens.load_feedback()
 
         # Split the data into training and testing sets
-        rs = RatioSplit(data=ml_100k, test_size=0.2, rating_threshold=4.0, seed=123)
+        rs = RatioSplit(data=ml_100k, test_size=0.1, val_size=0.1, rating_threshold=4.0, seed=123)
 
         # Instantiate Recall@100 for evaluation
         rec100 = cornac.metrics.Recall(100)


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

In the iamaresearcher.rst documentation, source codes for the example are incorrectly displayed. This result in inability to use GridSearch/RandomSearch for tuning hyperparameters.


### Related Issues
<!--- If it fixes an open issue, please link to the issue here. -->


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have added tests.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated `README.md` (if you are adding a new model).
- [ ] I have updated `examples/README.md` (if you are adding a new example).
- [ ] I have updated `datasets/README.md` (if you are adding a new dataset).
