### PR TITLE
Fix Pytest error in test cases due to Numpy 2.0 incompatibility

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,8 +17,9 @@ jobs:
           no_output_timeout: 30m
           command: |
             pip install --upgrade pip
-            pip install --only-binary=numpy,scipy numpy==1.22.4 scipy Cython pytest pytest-cov codecov
+            pip install --only-binary=numpy,scipy numpy==1.22.4 scipy==1.10.1 Cython pytest pytest-cov codecov
             pip install -e .[tests]
+            pip install numpy==1.22.4 scipy==1.10.1
       - run:
           name: Run tests
           no_output_timeout: 30m

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,6 +8,9 @@ jobs:
   build-and-test: 
     docker:
       - image: cimg/python:3.10.2
+        environment:
+          LIMIT_NUMPY_VERSION: 2.0.0
+          LIMIT_SCIPY_VERSION: 1.13.1
     steps:
       - checkout
       - python/install-packages:
@@ -17,9 +20,8 @@ jobs:
           no_output_timeout: 30m
           command: |
             pip install --upgrade pip
-            pip install --only-binary=numpy,scipy numpy==1.22.4 scipy==1.10.1 Cython pytest pytest-cov codecov
+            pip install --only-binary=numpy,scipy "numpy<$LIMIT_NUMPY_VERSION" "scipy<=$LIMIT_SCIPY_VERSION" Cython pytest pytest-cov codecov
             pip install -e .[tests]
-            pip install numpy==1.22.4 scipy==1.10.1
       - run:
           name: Run tests
           no_output_timeout: 30m

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -70,7 +70,7 @@ jobs:
         python${{ matrix.versions.python }} -m pip install numpy==${{ matrix.versions.numpy }} scipy==${{ matrix.versions.scipy }}
         python${{ matrix.versions.python }} setup.py build_ext -j${{ steps.cpu-cores.outputs.count }}
         python${{ matrix.versions.python }} -m pip install -e .[tests]
-        python${{ matrix.versions.python }} -m pip install numpy==${{ matrix.versions.numpy }} scipy==${{ matrix.versions.scipy }}
+        # python${{ matrix.versions.python }} -m pip install numpy==${{ matrix.versions.numpy }} scipy==${{ matrix.versions.scipy }}
 
     - name: Display numpy version
       run: python${{ matrix.versions.python }} -c "import numpy; print(numpy.__version__)"

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -67,10 +67,10 @@ jobs:
 
     - name: Install pinned dependencies - numpy ${{ matrix.versions.numpy }}, scipy ${{ matrix.versions.scipy }}
       run: |
+        python${{ matrix.versions.python }} -m pip install -e .[tests]
         python${{ matrix.versions.python }} -m pip uninstall numpy scipy
         python${{ matrix.versions.python }} -m pip install numpy==${{ matrix.versions.numpy }} scipy==${{ matrix.versions.scipy }}
         python${{ matrix.versions.python }} setup.py build_ext -j${{ steps.cpu-cores.outputs.count }}
-        # python${{ matrix.versions.python }} -m pip install -e .[tests]
 
     - name: Display numpy version
       run: python${{ matrix.versions.python }} -c "import numpy; print(numpy.__version__)"

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -70,7 +70,7 @@ jobs:
         python${{ matrix.versions.python }} -m pip uninstall numpy scipy
         python${{ matrix.versions.python }} -m pip install numpy==${{ matrix.versions.numpy }} scipy==${{ matrix.versions.scipy }}
         python${{ matrix.versions.python }} setup.py build_ext -j${{ steps.cpu-cores.outputs.count }}
-        python${{ matrix.versions.python }} -m pip install -e .[tests]
+        # python${{ matrix.versions.python }} -m pip install -e .[tests]
 
     - name: Display numpy version
       run: python${{ matrix.versions.python }} -c "import numpy; print(numpy.__version__)"

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -63,14 +63,14 @@ jobs:
       run: python${{ matrix.versions.python }} -m pip install wheel setuptools pip --upgrade
   
     - name: Install other dependencies
-      run: pip install Cython pytest pytest-cov flake8
+      run: python${{ matrix.versions.python }} -m pip install Cython pytest pytest-cov flake8
 
     - name: Install pinned dependencies - numpy ${{ matrix.versions.numpy }}, scipy ${{ matrix.versions.scipy }}
       run: |
-        pip uninstall numpy scipy
-        pip install numpy==${{ matrix.versions.numpy }} scipy==${{ matrix.versions.scipy }}
+        python${{ matrix.versions.python }} -m pip uninstall numpy scipy
+        python${{ matrix.versions.python }} -m pip install numpy==${{ matrix.versions.numpy }} scipy==${{ matrix.versions.scipy }}
         python${{ matrix.versions.python }} setup.py build_ext -j${{ steps.cpu-cores.outputs.count }}
-        pip install -e .[tests]
+        python${{ matrix.versions.python }} -m pip install -e .[tests]
 
     - name: Display numpy version
       run: python${{ matrix.versions.python }} -c "import numpy; print(numpy.__version__)"

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -63,13 +63,14 @@ jobs:
       run: python${{ matrix.versions.python }} -m pip install wheel setuptools pip --upgrade
   
     - name: Install other dependencies
-      run: |
-        pip install numpy scipy Cython pytest pytest-cov flake8
-        python${{ matrix.versions.python }} setup.py build_ext -j${{ steps.cpu-cores.outputs.count }}
-        pip install -e .[tests]
+      run: pip install Cython pytest pytest-cov flake8
 
     - name: Install pinned dependencies - numpy ${{ matrix.versions.numpy }}, scipy ${{ matrix.versions.scipy }}
-      run: pip install numpy==${{ matrix.versions.numpy }} scipy==${{ matrix.versions.scipy }}
+      run: |
+        pip uninstall numpy scipy
+        pip install numpy==${{ matrix.versions.numpy }} scipy==${{ matrix.versions.scipy }}
+        python${{ matrix.versions.python }} setup.py build_ext -j${{ steps.cpu-cores.outputs.count }}
+        pip install -e .[tests]
 
     - name: Display numpy version
       run: python${{ matrix.versions.python }} -c "import numpy; print(numpy.__version__)"

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -17,14 +17,10 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-latest, ubuntu-latest, macos-13, macos-14]
-        # python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
-        versions:
-          - { python: "3.8", numpy: 1.22.4, scipy: 1.10.1 }
-          - { python: "3.9", numpy: 1.22.4, scipy: 1.13.1 }
-          - { python: "3.10", numpy: 1.22.4, scipy: 1.13.1 }
-          - { python: "3.11", numpy: 1.24.3, scipy: 1.13.1 }
-          - { python: "3.12", numpy: 1.26.4, scipy: 1.13.1 }
-        
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+    env:
+      LIMIT_NUMPY_VERSION: 2.0.0
+      LIMIT_SCIPY_VERSION: 1.13.1
     steps:
     - name: Get number of CPU cores
       uses: SimenB/github-actions-cpu-cores@v2
@@ -32,47 +28,47 @@ jobs:
 
     - uses: actions/checkout@v4
 
-    - name: Setup Python ${{ matrix.versions.python }}
-      if: ${{ (matrix.os != 'macos-14') || ((matrix.os == 'macos-14') && (matrix.versions.python != '3.8') && (matrix.versions.python != '3.9')) }}
+    - name: Setup Python ${{ matrix.python-version }}
+      if: ${{ (matrix.os != 'macos-14') || ((matrix.os == 'macos-14') && (matrix.python-version != '3.8') && (matrix.python-version != '3.9')) }}
       uses: actions/setup-python@v5
       id: pysetup
       with:
-        python-version: ${{ matrix.versions.python }}
+        python-version: ${{ matrix.python-version }}
         cache: 'pip'
 
     - name: Setup Python 3.8-3.9 - macos-arm
-      if: ${{ (matrix.os == 'macos-14') && ((matrix.versions.python == '3.8') || (matrix.versions.python == '3.9')) }}
+      if: ${{ (matrix.os == 'macos-14') && ((matrix.python-version == '3.8') || (matrix.python-version == '3.9')) }}
       run: |
         brew update
-        brew install python@${{ matrix.versions.python }}
+        brew install python@${{ matrix.python-version }}
         curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
-        python${{ matrix.versions.python }} get-pip.py
+        python${{ matrix.python-version }} get-pip.py
 
     - name: Create Python alias for Windows 
       if: matrix.os == 'windows-latest'
       run: |
-        $newPath = "${{ steps.pysetup.outputs.python-path }}".Replace("python.exe", "python${{ matrix.versions.python }}.exe")
+        $newPath = "${{ steps.pysetup.outputs.python-path }}".Replace("python.exe", "python${{ matrix.python-version }}.exe")
         New-Item -ItemType HardLink -Path "$newPath" -Value "${{ steps.pysetup.outputs.python-path }}"
 
     - name: Display Python and Pip versions
       run: | 
-        python${{ matrix.versions.python }} -c "import sys; print(sys.version)"
+        python${{ matrix.python-version }} -c "import sys; print(sys.version)"
         pip --version
 
     - name: Upgrade pip wheel setuptools
-      run: python${{ matrix.versions.python }} -m pip install wheel setuptools pip --upgrade
+      run: python${{ matrix.python-version }} -m pip install wheel setuptools pip --upgrade
   
     - name: Install other dependencies
-      run: python${{ matrix.versions.python }} -m pip install Cython pytest pytest-cov flake8
+      run: python${{ matrix.python-version }} -m pip install Cython pytest pytest-cov flake8
 
-    - name: Install pinned dependencies - numpy ${{ matrix.versions.numpy }}, scipy ${{ matrix.versions.scipy }}
+    - name: Install other dependencies
       run: |
-        python${{ matrix.versions.python }} -m pip install "numpy<2.0.0" "scipy<=1.13.1"
-        python${{ matrix.versions.python }} setup.py build_ext -j${{ steps.cpu-cores.outputs.count }}
-        python${{ matrix.versions.python }} -m pip install -e .[tests]
+        python${{ matrix.python-version }} -m pip install Cython pytest pytest-cov flake8 "numpy<${{ env.LIMIT_NUMPY_VERSION }}" "scipy<=${{ env.LIMIT_SCIPY_VERSION }}"
+        python${{ matrix.python-version }} setup.py build_ext -j${{ steps.cpu-cores.outputs.count }}
+        python${{ matrix.python-version }} -m pip install -e .[tests]
 
     - name: Display numpy version
-      run: python${{ matrix.versions.python }} -c "import numpy; print(numpy.__version__)"
+      run: python${{ matrix.python-version }} -c "import numpy; print(numpy.__version__)"
 
     - name: Lint with flake8
       run: |
@@ -83,4 +79,4 @@ jobs:
     
     - name: Test with pytest
       run: |
-        python${{ matrix.versions.python }} -m pytest --cov=cornac
+        python${{ matrix.python-version }} -m pytest --cov=cornac

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -64,15 +64,15 @@ jobs:
 
     - name: Install numpy ${{ matrix.versions.numpy }}, scipy ${{ matrix.versions.scipy }}
       run: pip install numpy==${{ matrix.versions.numpy }} scipy==${{ matrix.versions.scipy }}
-    
-    - name: Display numpy version
-      run: python${{ matrix.versions.python }} -c "import numpy; print(numpy.__version__)"
-
+  
     - name: Install other dependencies
       run: |
         pip install Cython pytest pytest-cov flake8
         python${{ matrix.versions.python }} setup.py build_ext -j${{ steps.cpu-cores.outputs.count }}
         pip install -e .[tests]
+
+    - name: Display numpy version
+      run: python${{ matrix.versions.python }} -c "import numpy; print(numpy.__version__)"
 
     - name: Lint with flake8
       run: |
@@ -83,4 +83,4 @@ jobs:
     
     - name: Test with pytest
       run: |
-        pytest --cov=cornac
+        python${{ matrix.versions.python }} -m pytest --cov=cornac

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -19,7 +19,7 @@ jobs:
         os: [windows-latest, ubuntu-latest, macos-13, macos-14]
         # python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
         versions:
-          - { python: "3.8", numpy: 1.22.4, scipy: 1.13.1 }
+          - { python: "3.8", numpy: 1.22.4, scipy: 1.10.1 }
           - { python: "3.9", numpy: 1.22.4, scipy: 1.13.1 }
           - { python: "3.10", numpy: 1.22.4, scipy: 1.13.1 }
           - { python: "3.11", numpy: 1.24.3, scipy: 1.13.1 }

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -64,11 +64,11 @@ jobs:
   
     - name: Install other dependencies
       run: |
-        pip install Cython pytest pytest-cov flake8
+        pip install numpy scipy Cython pytest pytest-cov flake8
         python${{ matrix.versions.python }} setup.py build_ext -j${{ steps.cpu-cores.outputs.count }}
         pip install -e .[tests]
 
-    - name: Install numpy ${{ matrix.versions.numpy }}, scipy ${{ matrix.versions.scipy }}
+    - name: Install pinned dependencies - numpy ${{ matrix.versions.numpy }}, scipy ${{ matrix.versions.scipy }}
       run: pip install numpy==${{ matrix.versions.numpy }} scipy==${{ matrix.versions.scipy }}
 
     - name: Display numpy version

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -70,7 +70,6 @@ jobs:
         python${{ matrix.versions.python }} -m pip install numpy==${{ matrix.versions.numpy }} scipy==${{ matrix.versions.scipy }}
         python${{ matrix.versions.python }} setup.py build_ext -j${{ steps.cpu-cores.outputs.count }}
         python${{ matrix.versions.python }} -m pip install -e .[tests]
-        python${{ matrix.versions.python }} -m pip uninstall -y numpy scipy
         python${{ matrix.versions.python }} -m pip install numpy==${{ matrix.versions.numpy }} scipy==${{ matrix.versions.scipy }}
 
     - name: Display numpy version

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -19,11 +19,11 @@ jobs:
         os: [windows-latest, ubuntu-latest, macos-13, macos-14]
         # python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
         versions:
-          - { python: "3.8", numpy: 1.22.4 }
-          - { python: "3.9", numpy: 1.22.4 }
-          - { python: "3.10", numpy: 1.22.4 }
-          - { python: "3.11", numpy: 1.24.3 }
-          - { python: "3.12", numpy: 1.26.4 }
+          - { python: "3.8", numpy: 1.22.4, scipy: 1.13.1 }
+          - { python: "3.9", numpy: 1.22.4, scipy: 1.13.1 }
+          - { python: "3.10", numpy: 1.22.4, scipy: 1.13.1 }
+          - { python: "3.11", numpy: 1.24.3, scipy: 1.13.1 }
+          - { python: "3.12", numpy: 1.26.4, scipy: 1.13.1 }
         
     steps:
     - name: Get number of CPU cores
@@ -60,17 +60,17 @@ jobs:
         pip --version
 
     - name: Upgrade pip wheel setuptools
-      run: pip install wheel setuptools pip --upgrade
+      run: python${{ matrix.versions.python }} -m pip install wheel setuptools pip --upgrade
 
-    - name: Install numpy ${{ matrix.versions.numpy }}
-      run: pip install numpy==${{ matrix.versions.numpy }}
+    - name: Install numpy ${{ matrix.versions.numpy }}, scipy ${{ matrix.versions.scipy }}
+      run: pip install numpy==${{ matrix.versions.numpy }} scipy==${{ matrix.versions.scipy }}
     
     - name: Display numpy version
       run: python${{ matrix.versions.python }} -c "import numpy; print(numpy.__version__)"
 
     - name: Install other dependencies
       run: |
-        pip install scipy Cython pytest pytest-cov flake8
+        pip install Cython pytest pytest-cov flake8
         python${{ matrix.versions.python }} setup.py build_ext -j${{ steps.cpu-cores.outputs.count }}
         pip install -e .[tests]
 

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -67,10 +67,11 @@ jobs:
 
     - name: Install pinned dependencies - numpy ${{ matrix.versions.numpy }}, scipy ${{ matrix.versions.scipy }}
       run: |
+        python${{ matrix.versions.python }} -m pip install numpy==${{ matrix.versions.numpy }} scipy==${{ matrix.versions.scipy }}
+        python${{ matrix.versions.python }} setup.py build_ext -j${{ steps.cpu-cores.outputs.count }}
         python${{ matrix.versions.python }} -m pip install -e .[tests]
         python${{ matrix.versions.python }} -m pip uninstall numpy scipy
         python${{ matrix.versions.python }} -m pip install numpy==${{ matrix.versions.numpy }} scipy==${{ matrix.versions.scipy }}
-        python${{ matrix.versions.python }} setup.py build_ext -j${{ steps.cpu-cores.outputs.count }}
 
     - name: Display numpy version
       run: python${{ matrix.versions.python }} -c "import numpy; print(numpy.__version__)"

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -67,10 +67,9 @@ jobs:
 
     - name: Install pinned dependencies - numpy ${{ matrix.versions.numpy }}, scipy ${{ matrix.versions.scipy }}
       run: |
-        python${{ matrix.versions.python }} -m pip install numpy==${{ matrix.versions.numpy }} scipy==${{ matrix.versions.scipy }}
+        python${{ matrix.versions.python }} -m pip install numpy<2.0.0 scipy<=1.13.1
         python${{ matrix.versions.python }} setup.py build_ext -j${{ steps.cpu-cores.outputs.count }}
         python${{ matrix.versions.python }} -m pip install -e .[tests]
-        # python${{ matrix.versions.python }} -m pip install numpy==${{ matrix.versions.numpy }} scipy==${{ matrix.versions.scipy }}
 
     - name: Display numpy version
       run: python${{ matrix.versions.python }} -c "import numpy; print(numpy.__version__)"

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -67,7 +67,7 @@ jobs:
 
     - name: Install pinned dependencies - numpy ${{ matrix.versions.numpy }}, scipy ${{ matrix.versions.scipy }}
       run: |
-        python${{ matrix.versions.python }} -m pip install numpy<2.0.0 scipy<=1.13.1
+        python${{ matrix.versions.python }} -m pip install "numpy<2.0.0" "scipy<=1.13.1"
         python${{ matrix.versions.python }} setup.py build_ext -j${{ steps.cpu-cores.outputs.count }}
         python${{ matrix.versions.python }} -m pip install -e .[tests]
 

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -61,15 +61,15 @@ jobs:
 
     - name: Upgrade pip wheel setuptools
       run: python${{ matrix.versions.python }} -m pip install wheel setuptools pip --upgrade
-
-    - name: Install numpy ${{ matrix.versions.numpy }}, scipy ${{ matrix.versions.scipy }}
-      run: pip install numpy==${{ matrix.versions.numpy }} scipy==${{ matrix.versions.scipy }}
   
     - name: Install other dependencies
       run: |
         pip install Cython pytest pytest-cov flake8
         python${{ matrix.versions.python }} setup.py build_ext -j${{ steps.cpu-cores.outputs.count }}
         pip install -e .[tests]
+
+    - name: Install numpy ${{ matrix.versions.numpy }}, scipy ${{ matrix.versions.scipy }}
+      run: pip install numpy==${{ matrix.versions.numpy }} scipy==${{ matrix.versions.scipy }}
 
     - name: Display numpy version
       run: python${{ matrix.versions.python }} -c "import numpy; print(numpy.__version__)"

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -70,7 +70,7 @@ jobs:
         python${{ matrix.versions.python }} -m pip install numpy==${{ matrix.versions.numpy }} scipy==${{ matrix.versions.scipy }}
         python${{ matrix.versions.python }} setup.py build_ext -j${{ steps.cpu-cores.outputs.count }}
         python${{ matrix.versions.python }} -m pip install -e .[tests]
-        python${{ matrix.versions.python }} -m pip uninstall numpy scipy
+        python${{ matrix.versions.python }} -m pip uninstall -y numpy scipy
         python${{ matrix.versions.python }} -m pip install numpy==${{ matrix.versions.numpy }} scipy==${{ matrix.versions.scipy }}
 
     - name: Display numpy version

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -12,6 +12,10 @@ on:
   release:
     types: [published]
 
+env:
+  LIMIT_NUMPY_VERSION: 2.0.0
+  LIMIT_SCIPY_VERSION: 1.13.1
+
 jobs:
   build-wheels:
     name: Building on ${{ matrix.os }}
@@ -20,58 +24,52 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-latest, ubuntu-latest, macos-13, macos-14]
-        versions:
-          - { python: "3.8", numpy: 1.22.4, scipy: 1.13.1 }
-          - { python: "3.9", numpy: 1.22.4, scipy: 1.13.1 }
-          - { python: "3.10", numpy: 1.22.4, scipy: 1.13.1 }
-          - { python: "3.11", numpy: 1.24.3, scipy: 1.13.1 }
-          - { python: "3.12", numpy: 1.26.4, scipy: 1.13.1 }
-
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
     steps:
     - uses: actions/checkout@v4
     
-    - name: Setup Python ${{ matrix.versions.python }}
-      if: ${{ (matrix.os != 'macos-14') || ((matrix.os == 'macos-14') && (matrix.versions.python != '3.8') && (matrix.versions.python != '3.9')) }}
+    - name: Setup Python ${{ matrix.python-version }}
+      if: ${{ (matrix.os != 'macos-14') || ((matrix.os == 'macos-14') && (matrix.python-version != '3.8') && (matrix.python-version != '3.9')) }}
       uses: actions/setup-python@v5
       id: pysetup
       with:
-        python-version: ${{ matrix.versions.python }}
+        python-version: ${{ matrix.python-version }}
         cache: 'pip'
 
     - name: Setup Python 3.8-3.9 - macos-arm
-      if: ${{ (matrix.os == 'macos-14') && ((matrix.versions.python == '3.8') || (matrix.versions.python == '3.9')) }}
+      if: ${{ (matrix.os == 'macos-14') && ((matrix.python-version == '3.8') || (matrix.python-version == '3.9')) }}
       run: |
         brew update
-        brew install python@${{ matrix.versions.python }}
+        brew install python@${{ matrix.python-version }}
         curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
-        python${{ matrix.versions.python }} get-pip.py
+        python${{ matrix.python-version }} get-pip.py
 
     - name: Create Python alias for Windows 
       if: matrix.os == 'windows-latest'
       run: |
-        $newPath = "${{ steps.pysetup.outputs.python-path }}".Replace("python.exe", "python${{ matrix.versions.python }}.exe")
+        $newPath = "${{ steps.pysetup.outputs.python-path }}".Replace("python.exe", "python${{ matrix.python-version }}.exe")
         New-Item -ItemType HardLink -Path "$newPath" -Value "${{ steps.pysetup.outputs.python-path }}"
 
     - name: Display Python and Pip versions
       run: | 
-        python${{ matrix.versions.python }} -c "import sys; print(sys.version)"
+        python${{ matrix.python-version }} -c "import sys; print(sys.version)"
         pip --version
 
     - name: Upgrade pip wheel setuptools
-      run: python${{ matrix.versions.python }} -m pip install wheel setuptools pip --upgrade
+      run: python${{ matrix.python-version }} -m pip install wheel setuptools pip --upgrade
 
-    - name: Install numpy ${{ matrix.versions.numpy }}, scipy ${{ matrix.versions.scipy }}
-      run: pip install numpy==${{ matrix.versions.numpy }} scipy==${{ matrix.versions.scipy }}
+    - name: Install numpy, scipy
+      run: pip install "numpy<${{ env.LIMIT_NUMPY_VERSION }}" "scipy<=${{ env.LIMIT_SCIPY_VERSION }}"
     
     - name: Install other dependencies
       run: |
         pip install Cython wheel
     
     - name: Display numpy version
-      run: python${{ matrix.versions.python }} -c "import numpy; print(numpy.__version__)"
+      run: python${{ matrix.python-version }} -c "import numpy; print(numpy.__version__)"
 
     - name: Build wheels
-      run: python${{ matrix.versions.python }} setup.py bdist_wheel
+      run: python${{ matrix.python-version }} setup.py bdist_wheel
         
     - name: Rename Linux wheels to supported platform of PyPI
       if: matrix.os == 'ubuntu-latest'
@@ -105,7 +103,7 @@ jobs:
 
     - name: Install numpy
       run: |
-        python -m pip install numpy==1.22.4 scipy==1.13.1
+        python -m pip install "numpy<${{ env.LIMIT_NUMPY_VERSION }}" "scipy<=${{ env.LIMIT_SCIPY_VERSION }}"
         python -c "import numpy; print(numpy.__version__)"
 
     - name: Install other dependencies

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -21,11 +21,11 @@ jobs:
       matrix:
         os: [windows-latest, ubuntu-latest, macos-13, macos-14]
         versions:
-          - { python: "3.8", numpy: 1.22.4 }
-          - { python: "3.9", numpy: 1.22.4 }
-          - { python: "3.10", numpy: 1.22.4 }
-          - { python: "3.11", numpy: 1.24.3 }
-          - { python: "3.12", numpy: 1.26.4 }
+          - { python: "3.8", numpy: 1.22.4, scipy: 1.13.1 }
+          - { python: "3.9", numpy: 1.22.4, scipy: 1.13.1 }
+          - { python: "3.10", numpy: 1.22.4, scipy: 1.13.1 }
+          - { python: "3.11", numpy: 1.24.3, scipy: 1.13.1 }
+          - { python: "3.12", numpy: 1.26.4, scipy: 1.13.1 }
 
     steps:
     - uses: actions/checkout@v4
@@ -60,15 +60,15 @@ jobs:
     - name: Upgrade pip wheel setuptools
       run: pip install wheel setuptools pip --upgrade
 
-    - name: Install numpy ${{ matrix.versions.numpy }}
-      run: pip install numpy==${{ matrix.versions.numpy }}
+    - name: Install numpy ${{ matrix.versions.numpy }}, scipy ${{ matrix.versions.scipy }}
+      run: pip install numpy==${{ matrix.versions.numpy }} scipy==${{ matrix.versions.scipy }}
     
     - name: Display numpy version
       run: python${{ matrix.versions.python }} -c "import numpy; print(numpy.__version__)"
 
     - name: Install other dependencies
       run: |
-        pip install scipy Cython wheel
+        pip install Cython wheel
     
     - name: Build wheels
       run: python${{ matrix.versions.python }} setup.py bdist_wheel
@@ -105,12 +105,12 @@ jobs:
 
     - name: Install numpy
       run: |
-        python -m pip install numpy==1.22.4
+        python -m pip install numpy==1.22.4 scipy==1.13.1
         python -c "import numpy; print(numpy.__version__)"
 
     - name: Install other dependencies
       run: |
-        python -m pip install scipy Cython wheel
+        python -m pip install Cython wheel
 
     - name: Build source tar file
       run: python setup.py sdist

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -63,13 +63,13 @@ jobs:
     - name: Install numpy ${{ matrix.versions.numpy }}, scipy ${{ matrix.versions.scipy }}
       run: pip install numpy==${{ matrix.versions.numpy }} scipy==${{ matrix.versions.scipy }}
     
-    - name: Display numpy version
-      run: python${{ matrix.versions.python }} -c "import numpy; print(numpy.__version__)"
-
     - name: Install other dependencies
       run: |
         pip install Cython wheel
     
+    - name: Display numpy version
+      run: python${{ matrix.versions.python }} -c "import numpy; print(numpy.__version__)"
+
     - name: Build wheels
       run: python${{ matrix.versions.python }} setup.py bdist_wheel
         

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -58,7 +58,7 @@ jobs:
         pip --version
 
     - name: Upgrade pip wheel setuptools
-      run: pip install wheel setuptools pip --upgrade
+      run: python${{ matrix.versions.python }} -m pip install wheel setuptools pip --upgrade
 
     - name: Install numpy ${{ matrix.versions.numpy }}, scipy ${{ matrix.versions.scipy }}
       run: pip install numpy==${{ matrix.versions.numpy }} scipy==${{ matrix.versions.scipy }}

--- a/setup.py
+++ b/setup.py
@@ -343,7 +343,7 @@ setup(
         "recommendation",
     ],
     ext_modules=extensions,
-    install_requires=["numpy<=1.26", "scipy<=1.13", "tqdm", "powerlaw"],
+    install_requires=["numpy<2.0.0", "scipy<=1.13.1", "tqdm", "powerlaw"],
     extras_require={"tests": ["pytest", "pytest-pep8", "pytest-xdist", "pytest-cov", "Flask"]},
     cmdclass=cmdclass,
     packages=find_packages(),

--- a/setup.py
+++ b/setup.py
@@ -343,7 +343,7 @@ setup(
         "recommendation",
     ],
     ext_modules=extensions,
-    install_requires=["numpy", "scipy", "tqdm", "powerlaw"],
+    install_requires=["numpy<=1.26", "scipy<=1.13", "tqdm", "powerlaw"],
     extras_require={"tests": ["pytest", "pytest-pep8", "pytest-xdist", "pytest-cov", "Flask"]},
     cmdclass=cmdclass,
     packages=find_packages(),


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

In our unit tests, pytest throws failures due to incompatibility of the `np.Inf` being deprecated (A deprecation in Numpy 2.0).

We pin the version of `numpy<2.0.0`, and `scipy<=1.13.1`. In a separate issue and PR, we will resolve codes regarding Numpy 2.0 errors.

### Related Issues
<!--- If it fixes an open issue, please link to the issue here. -->


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have added tests.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated `README.md` (if you are adding a new model).
- [ ] I have updated `examples/README.md` (if you are adding a new example).
- [ ] I have updated `datasets/README.md` (if you are adding a new dataset).
