### PR TITLE
Fix issue #628 with '.A' stuff on csr_matrix

### DIFF
--- a/cornac/data/text.py
+++ b/cornac/data/text.py
@@ -974,6 +974,7 @@ class TextModality(FeatureModality):
         tfidf_mat = self.tfidf_matrix[batch_ids]
         return tfidf_mat if keep_sparse else tfidf_mat.A
 
+
 class ReviewModality(TextModality):
     """Review modality
 
@@ -1034,6 +1035,7 @@ class ReviewModality(TextModality):
             Apply sublinear tf scaling, i.e. replace tf with 1 + log(tf).
 
     """
+
     def __init__(self,
                  data: List[tuple] = None,
                  group_by: str = None,

--- a/cornac/data/text.py
+++ b/cornac/data/text.py
@@ -951,7 +951,7 @@ class TextModality(FeatureModality):
         if binary:
             bow_mat.data.fill(1)
 
-        return bow_mat if keep_sparse else bow_mat.A
+        return bow_mat if keep_sparse else bow_mat.toarray()
 
     def batch_tfidf(self, batch_ids, keep_sparse=False):
         """Return matrix of TF-IDF features corresponding to provided batch_ids
@@ -972,7 +972,7 @@ class TextModality(FeatureModality):
 
         """
         tfidf_mat = self.tfidf_matrix[batch_ids]
-        return tfidf_mat if keep_sparse else tfidf_mat.A
+        return tfidf_mat if keep_sparse else tfidf_mat.toarray()
 
 
 class ReviewModality(TextModality):

--- a/cornac/models/knn/recom_knn.py
+++ b/cornac/models/knn/recom_knn.py
@@ -239,7 +239,7 @@ class UserKNN(Recommender):
         if item_idx is not None:
             weighted_avg = compute_score_single(
                 True,
-                self.sim_mat[user_idx].A.ravel(),
+                self.sim_mat[user_idx].toarray().ravel(),
                 self.iu_mat.indptr[item_idx],
                 self.iu_mat.indptr[item_idx + 1],
                 self.iu_mat.indices,
@@ -251,7 +251,7 @@ class UserKNN(Recommender):
         weighted_avg = np.zeros(self.num_items)
         compute_score(
             True,
-            self.sim_mat[user_idx].A.ravel(),
+            self.sim_mat[user_idx].toarray().ravel(),
             self.iu_mat.indptr,
             self.iu_mat.indices,
             self.iu_mat.data,
@@ -412,7 +412,7 @@ class ItemKNN(Recommender):
         if item_idx is not None:
             weighted_avg = compute_score_single(
                 False,
-                self.ui_mat[user_idx].A.ravel(),
+                self.ui_mat[user_idx].toarray().ravel(),
                 self.sim_mat.indptr[item_idx],
                 self.sim_mat.indptr[item_idx + 1],
                 self.sim_mat.indices,
@@ -424,7 +424,7 @@ class ItemKNN(Recommender):
         weighted_avg = np.zeros(self.num_items)
         compute_score(
             False,
-            self.ui_mat[user_idx].A.ravel(),
+            self.ui_mat[user_idx].toarray().ravel(),
             self.sim_mat.indptr,
             self.sim_mat.indices,
             self.sim_mat.data,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-numpy<=1.26
+numpy<2.0
 scipy
 Cython
 tqdm

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-numpy
+numpy<=1.26
 scipy
 Cython
 tqdm


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
Fix the issue concerning '.A' alias deprecated with latest Scipy version (from 1.11).
Change '.A' to '.toarray()' in scoring functions in knn models.
Also fixing upper bound on numpy version until compatibility is done in requirements

### Related Issues
<!--- If it fixes an open issue, please link to the issue here. -->
Fix #629 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have added tests.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated `README.md` (if you are adding a new model).
- [ ] I have updated `examples/README.md` (if you are adding a new example).
- [ ] I have updated `datasets/README.md` (if you are adding a new dataset).
