### PR TITLE
Add multimodality table to documentation

### DIFF
--- a/docs/generate_model_js.py
+++ b/docs/generate_model_js.py
@@ -47,8 +47,6 @@ def add_modalities_for_model(model):
         "Item Graph": "item_graph",
         "Sentiment": "sentiment",
         "Review Text": "review_text",
-        "User Feature": "user_feature",
-        "Item Feature": "item_feature",
     }
     
     for filename in glob.glob(f'../{model["Link"]}/*.py', recursive=True):
@@ -59,6 +57,21 @@ def add_modalities_for_model(model):
                 is_found = modality_keyword in file_data
                 if is_found:
                     model[header] = True
+            
+            # for user feature and item feature
+            # >> if user feature is found, we set user text, image and graph to true
+            is_found = "user_feature" in file_data
+            if is_found:
+                model["User Text"] = True
+                model["User Image"] = True
+                model["User Graph"] = True
+                
+            # likewise for item feature
+            is_found = "item_feature" in file_data
+            if is_found:
+                model["Item Text"] = True
+                model["Item Image"] = True
+                model["Item Graph"] = True
     
     for header, modality_keyword in modalities_keywords.items():
         if header not in model:

--- a/docs/generate_model_js.py
+++ b/docs/generate_model_js.py
@@ -1,5 +1,6 @@
 import json
-
+import os
+import glob
 
 def get_key_val(part):
     key_index_start = part.index('[')
@@ -13,48 +14,8 @@ def get_key_val(part):
     return key, val
 
 
-# Read the content from README.md
-with open('../README.md', 'r') as file:
-    content = file.read()
-
-# Extract the relevant information from the content
-models = []
-lines = content.split('\n')
-lines = lines[lines.index('## Models') + 4: lines.index('## Resources') - 2]
-
-headers = []
-headers = lines[0].split('|')[1:-1]
-headers = [header.strip() for header in headers]
-
-for line in lines[2:]:
-    parts = line.split('|')[1:-1]
-    parts = [part.strip() for part in parts]
-    model = dict(zip(headers, parts))
-    models.append(model)
-
-year = None
-
-for model in models:
-    # handle empty years
-    if model["Year"] == "":
-        model["Year"] = year
-    else:
-        year = model["Year"]
-        
-    # handle model, docs and paper part
-    name_paper_str = model["Model and Paper"]
-
-    for i, part in enumerate(name_paper_str.split(', ')):
-        key, val = get_key_val(part)
-
-        if i == 0:
-            model["Name"] = key
-            model["Link"] = val
-        else:
-            model[key] = val
-    
+def add_pytorch_tensorflow(model):
     # handle environment part
-    
     env_part = model["Environment"].split(', ')[0]
     
     search_dict = {
@@ -74,28 +35,104 @@ for model in models:
     else:
         for header, _ in search_dict.items():
             model[header] = False
-    
-    # remove non required keys
-    model.pop("Model and Paper")
-    model.pop("Environment")
-    
-    # Get package name
-    model_dir = model["Link"]
-    
-    with open(f'../{model_dir}/__init__.py', 'r') as file:
-        init_data = file.read()
-        
-        package_names = []
-        
-        for row in init_data.split('\n'):
-            if "import" in row:
-                package_name = row[row.index("import") + len("import "):]
-                package_names.append(f"cornac.models.{package_name}")
-        
-        model["packages"] = package_names
 
-json_str = json.dumps(models, indent=4)
 
-# Write the JSON object to a file
-with open('source/_static/models/data.js', 'w') as file:
-    file.write(f"var data = {json_str};")
+def add_modalities_for_model(model):
+    modalities_keywords = {
+        "User Text": "user_text",
+        "User Image": "user_image",
+        "User Graph": "user_graph",
+        "Item Text": "item_text",
+        "Item Image": "item_image",
+        "Item Graph": "item_graph",
+        "Sentiment": "sentiment",
+        "Review Text": "review_text",
+        "User Feature": "user_feature",
+        "Item Feature": "item_feature",
+    }
+    
+    for filename in glob.glob(f'../{model["Link"]}/*.py', recursive=True):
+        with open(filename, 'r') as file:
+            file_data = file.read()
+            
+            for header, modality_keyword in modalities_keywords.items():
+                is_found = modality_keyword in file_data
+                if is_found:
+                    model[header] = True
+    
+    for header, modality_keyword in modalities_keywords.items():
+        if header not in model:
+            model[header] = False
+
+
+if __name__ == "__main__":
+    # Read the content from README.md
+    with open('../README.md', 'r') as file:
+        content = file.read()
+
+    # Extract the relevant information from the content
+    models = []
+    lines = content.split('\n')
+    lines = lines[lines.index('## Models') + 4: lines.index('## Resources') - 2]
+
+    headers = []
+    headers = lines[0].split('|')[1:-1]
+    headers = [header.strip() for header in headers]
+
+    for line in lines[2:]:
+        parts = line.split('|')[1:-1]
+        parts = [part.strip() for part in parts]
+        model = dict(zip(headers, parts))
+        models.append(model)
+
+    year = None
+
+    for model in models:
+        # handle empty years
+        if model["Year"] == "":
+            model["Year"] = year
+        else:
+            year = model["Year"]
+            
+        # handle model, docs and paper part
+        name_paper_str = model["Model and Paper"]
+
+        for i, part in enumerate(name_paper_str.split(', ')):
+            key, val = get_key_val(part)
+
+            if i == 0:
+                model["Name"] = key
+                model["Link"] = val
+            else:
+                model[key] = val
+        
+        # Check for PyTorch and TensorFlow in each requirements file
+        add_pytorch_tensorflow(model)
+        
+        # Check for modalities keywords in files and add to model
+        add_modalities_for_model(model)
+                    
+        # remove non required keys
+        model.pop("Model and Paper")
+        model.pop("Environment")
+        
+        # Get package name
+        model_dir = model["Link"]
+        
+        with open(f'../{model_dir}/__init__.py', 'r') as file:
+            init_data = file.read()
+            
+            package_names = []
+            
+            for row in init_data.split('\n'):
+                if "import" in row:
+                    package_name = row[row.index("import") + len("import "):]
+                    package_names.append(f"cornac.models.{package_name}")
+            
+            model["packages"] = package_names
+
+    json_str = json.dumps(models, indent=4)
+
+    # Write the JSON object to a file
+    with open('source/_static/models/data.js', 'w') as file:
+        file.write(f"var data = {json_str};")

--- a/docs/source/_static/models/data.js
+++ b/docs/source/_static/models/data.js
@@ -8,6 +8,16 @@ var data = [
         "paper": "https://doi.org/10.1007/978-3-031-56027-9_14",
         "PyTorch": true,
         "TensorFlow": false,
+        "Sentiment": true,
+        "Review Text": true,
+        "User Text": false,
+        "User Image": false,
+        "User Graph": false,
+        "Item Text": false,
+        "Item Image": false,
+        "Item Graph": false,
+        "User Feature": false,
+        "Item Feature": false,
         "packages": [
             "cornac.models.HypAR"
         ]
@@ -21,6 +31,16 @@ var data = [
         "paper": "https://arxiv.org/pdf/2203.05406.pdf",
         "PyTorch": true,
         "TensorFlow": false,
+        "Item Text": true,
+        "Item Image": true,
+        "User Text": false,
+        "User Image": false,
+        "User Graph": false,
+        "Item Graph": false,
+        "Sentiment": false,
+        "Review Text": false,
+        "User Feature": false,
+        "Item Feature": false,
         "packages": [
             "cornac.models.DMRL"
         ]
@@ -34,6 +54,16 @@ var data = [
         "paper": "https://dl.acm.org/doi/pdf/10.1145/3437963.3441759",
         "PyTorch": true,
         "TensorFlow": false,
+        "User Feature": true,
+        "Item Feature": true,
+        "User Text": false,
+        "User Image": false,
+        "User Graph": false,
+        "Item Text": false,
+        "Item Image": false,
+        "Item Graph": false,
+        "Sentiment": false,
+        "Review Text": false,
         "packages": [
             "cornac.models.BiVAECF"
         ]
@@ -47,6 +77,16 @@ var data = [
         "paper": "https://arxiv.org/abs/2107.02390",
         "PyTorch": true,
         "TensorFlow": false,
+        "Item Image": true,
+        "User Text": false,
+        "User Image": false,
+        "User Graph": false,
+        "Item Text": false,
+        "Item Graph": false,
+        "Sentiment": false,
+        "Review Text": false,
+        "User Feature": false,
+        "Item Feature": false,
         "packages": [
             "cornac.models.CausalRec"
         ]
@@ -60,6 +100,16 @@ var data = [
         "paper": "https://dl.acm.org/doi/pdf/10.1145/3437963.3441754",
         "PyTorch": false,
         "TensorFlow": false,
+        "User Text": false,
+        "User Image": false,
+        "User Graph": false,
+        "Item Text": false,
+        "Item Image": false,
+        "Item Graph": false,
+        "Sentiment": false,
+        "Review Text": false,
+        "User Feature": false,
+        "Item Feature": false,
         "packages": [
             "cornac.models.ComparERSub",
             "cornac.models.ComparERObj"
@@ -74,6 +124,16 @@ var data = [
         "paper": "https://ieeexplore.ieee.org/document/8618394",
         "PyTorch": true,
         "TensorFlow": false,
+        "Item Image": true,
+        "User Text": false,
+        "User Image": false,
+        "User Graph": false,
+        "Item Text": false,
+        "Item Graph": false,
+        "Sentiment": false,
+        "Review Text": false,
+        "User Feature": false,
+        "Item Feature": false,
         "packages": [
             "cornac.models.AMR"
         ]
@@ -87,6 +147,16 @@ var data = [
         "paper": "https://www.sciencedirect.com/science/article/abs/pii/S0925231219313207",
         "PyTorch": false,
         "TensorFlow": true,
+        "User Text": true,
+        "Item Text": true,
+        "Review Text": true,
+        "User Image": false,
+        "User Graph": false,
+        "Item Image": false,
+        "Item Graph": false,
+        "Sentiment": false,
+        "User Feature": false,
+        "Item Feature": false,
         "packages": [
             "cornac.models.HRDR"
         ]
@@ -100,6 +170,16 @@ var data = [
         "paper": "https://arxiv.org/pdf/2002.02126.pdf",
         "PyTorch": true,
         "TensorFlow": false,
+        "User Text": false,
+        "User Image": false,
+        "User Graph": false,
+        "Item Text": false,
+        "Item Image": false,
+        "Item Graph": false,
+        "Sentiment": false,
+        "Review Text": false,
+        "User Feature": false,
+        "Item Feature": false,
         "packages": [
             "cornac.models.LightGCN"
         ]
@@ -113,6 +193,16 @@ var data = [
         "paper": "https://arxiv.org/pdf/2006.11483.pdf",
         "PyTorch": true,
         "TensorFlow": false,
+        "User Text": false,
+        "User Image": false,
+        "User Graph": false,
+        "Item Text": false,
+        "Item Image": false,
+        "Item Graph": false,
+        "Sentiment": false,
+        "Review Text": false,
+        "User Feature": false,
+        "Item Feature": false,
         "packages": [
             "cornac.models.DNNTSP"
         ]
@@ -126,6 +216,16 @@ var data = [
         "paper": "https://dl.acm.org/doi/abs/10.1145/3340631.3394850",
         "PyTorch": false,
         "TensorFlow": false,
+        "User Text": false,
+        "User Image": false,
+        "User Graph": false,
+        "Item Text": false,
+        "Item Image": false,
+        "Item Graph": false,
+        "Sentiment": false,
+        "Review Text": false,
+        "User Feature": false,
+        "Item Feature": false,
         "packages": [
             "cornac.models.UPCF"
         ]
@@ -139,6 +239,16 @@ var data = [
         "paper": "https://arxiv.org/pdf/2006.00556.pdf",
         "PyTorch": false,
         "TensorFlow": false,
+        "User Text": false,
+        "User Image": false,
+        "User Graph": false,
+        "Item Text": false,
+        "Item Image": false,
+        "Item Graph": false,
+        "Sentiment": false,
+        "Review Text": false,
+        "User Feature": false,
+        "Item Feature": false,
         "packages": [
             "cornac.models.TIFUKNN"
         ]
@@ -152,6 +262,16 @@ var data = [
         "paper": "https://doi.org/10.1145/3336191.3371831",
         "PyTorch": true,
         "TensorFlow": false,
+        "User Text": false,
+        "User Image": false,
+        "User Graph": false,
+        "Item Text": false,
+        "Item Image": false,
+        "Item Graph": false,
+        "Sentiment": false,
+        "Review Text": false,
+        "User Feature": false,
+        "Item Feature": false,
         "packages": [
             "cornac.models.RecVAE"
         ]
@@ -165,6 +285,16 @@ var data = [
         "paper": "https://www.ijcai.org/proceedings/2019/0389.pdf",
         "PyTorch": false,
         "TensorFlow": true,
+        "User Text": false,
+        "User Image": false,
+        "User Graph": false,
+        "Item Text": false,
+        "Item Image": false,
+        "Item Graph": false,
+        "Sentiment": false,
+        "Review Text": false,
+        "User Feature": false,
+        "Item Feature": false,
         "packages": [
             "cornac.models.Beacon"
         ]
@@ -178,6 +308,16 @@ var data = [
         "paper": "https://arxiv.org/pdf/1905.03375.pdf",
         "PyTorch": false,
         "TensorFlow": false,
+        "User Text": false,
+        "User Image": false,
+        "User Graph": false,
+        "Item Text": false,
+        "Item Image": false,
+        "Item Graph": false,
+        "Sentiment": false,
+        "Review Text": false,
+        "User Feature": false,
+        "Item Feature": false,
         "packages": [
             "cornac.models.EASE"
         ]
@@ -191,6 +331,16 @@ var data = [
         "paper": "https://arxiv.org/pdf/1905.08108.pdf",
         "PyTorch": true,
         "TensorFlow": false,
+        "User Text": false,
+        "User Image": false,
+        "User Graph": false,
+        "Item Text": false,
+        "Item Image": false,
+        "Item Graph": false,
+        "Sentiment": false,
+        "Review Text": false,
+        "User Feature": false,
+        "Item Feature": false,
         "packages": [
             "cornac.models.NGCF"
         ]
@@ -204,6 +354,16 @@ var data = [
         "paper": "https://www.ijcai.org/proceedings/2018/0370.pdf",
         "PyTorch": false,
         "TensorFlow": false,
+        "Item Graph": true,
+        "User Text": false,
+        "User Image": false,
+        "User Graph": false,
+        "Item Text": false,
+        "Item Image": false,
+        "Sentiment": false,
+        "Review Text": false,
+        "User Feature": false,
+        "Item Feature": false,
         "packages": [
             "cornac.models.C2PF"
         ]
@@ -217,6 +377,16 @@ var data = [
         "paper": "https://www.kdd.org/kdd2018/files/deep-learning-day/DLDay18_paper_32.pdf",
         "PyTorch": true,
         "TensorFlow": false,
+        "User Graph": true,
+        "User Text": false,
+        "User Image": false,
+        "Item Text": false,
+        "Item Image": false,
+        "Item Graph": false,
+        "Sentiment": false,
+        "Review Text": false,
+        "User Feature": false,
+        "Item Feature": false,
         "packages": [
             "cornac.models.GCMC"
         ]
@@ -230,6 +400,16 @@ var data = [
         "paper": "https://arxiv.org/pdf/1806.03568.pdf",
         "PyTorch": false,
         "TensorFlow": false,
+        "User Text": false,
+        "User Image": false,
+        "User Graph": false,
+        "Item Text": false,
+        "Item Image": false,
+        "Item Graph": false,
+        "Sentiment": false,
+        "Review Text": false,
+        "User Feature": false,
+        "Item Feature": false,
         "packages": [
             "cornac.models.MTER"
         ]
@@ -243,6 +423,16 @@ var data = [
         "paper": "http://www.thuir.cn/group/~YQLiu/publications/WWW2018_CC.pdf",
         "PyTorch": false,
         "TensorFlow": true,
+        "Review Text": true,
+        "User Text": true,
+        "Item Text": true,
+        "User Image": false,
+        "User Graph": false,
+        "Item Image": false,
+        "Item Graph": false,
+        "Sentiment": false,
+        "User Feature": false,
+        "Item Feature": false,
         "packages": [
             "cornac.models.NARRE"
         ]
@@ -256,6 +446,16 @@ var data = [
         "paper": "http://www.hadylauw.com/publications/uai18.pdf",
         "PyTorch": false,
         "TensorFlow": true,
+        "Item Graph": true,
+        "User Text": false,
+        "User Image": false,
+        "User Graph": false,
+        "Item Text": false,
+        "Item Image": false,
+        "Sentiment": false,
+        "Review Text": false,
+        "User Feature": false,
+        "Item Feature": false,
         "packages": [
             "cornac.models.PCRL"
         ]
@@ -269,6 +469,16 @@ var data = [
         "paper": "https://arxiv.org/pdf/1802.05814.pdf",
         "PyTorch": true,
         "TensorFlow": false,
+        "User Text": false,
+        "User Image": false,
+        "User Graph": false,
+        "Item Text": false,
+        "Item Image": false,
+        "Item Graph": false,
+        "Sentiment": false,
+        "Review Text": false,
+        "User Feature": false,
+        "Item Feature": false,
         "packages": [
             "cornac.models.VAECF"
         ]
@@ -282,6 +492,16 @@ var data = [
         "paper": "http://eelxpeng.github.io/assets/paper/Collaborative_Variational_Autoencoder.pdf",
         "PyTorch": false,
         "TensorFlow": true,
+        "Item Text": true,
+        "User Text": false,
+        "User Image": false,
+        "User Graph": false,
+        "Item Image": false,
+        "Item Graph": false,
+        "Sentiment": false,
+        "Review Text": false,
+        "User Feature": false,
+        "Item Feature": false,
         "packages": [
             "cornac.models.CVAE"
         ]
@@ -295,6 +515,16 @@ var data = [
         "paper": "https://dl.acm.org/doi/10.1145/3132847.3132972",
         "PyTorch": true,
         "TensorFlow": false,
+        "User Graph": true,
+        "User Text": false,
+        "User Image": false,
+        "Item Text": false,
+        "Item Image": false,
+        "Item Graph": false,
+        "Sentiment": false,
+        "Review Text": false,
+        "User Feature": false,
+        "Item Feature": false,
         "packages": [
             "cornac.models.CVAECF"
         ]
@@ -308,6 +538,16 @@ var data = [
         "paper": "https://arxiv.org/pdf/1708.05031.pdf",
         "PyTorch": true,
         "TensorFlow": true,
+        "User Text": false,
+        "User Image": false,
+        "User Graph": false,
+        "Item Text": false,
+        "Item Image": false,
+        "Item Graph": false,
+        "Sentiment": false,
+        "Review Text": false,
+        "User Feature": false,
+        "Item Feature": false,
         "packages": [
             "cornac.models.GMF",
             "cornac.models.MLP",
@@ -323,6 +563,16 @@ var data = [
         "paper": "http://www.hadylauw.com/publications/cikm17a.pdf",
         "PyTorch": true,
         "TensorFlow": false,
+        "User Text": false,
+        "User Image": false,
+        "User Graph": false,
+        "Item Text": false,
+        "Item Image": false,
+        "Item Graph": false,
+        "Sentiment": false,
+        "Review Text": false,
+        "User Feature": false,
+        "Item Feature": false,
         "packages": [
             "cornac.models.IBPR"
         ]
@@ -336,6 +586,16 @@ var data = [
         "paper": "https://dsail.kaist.ac.kr/files/WWW17.pdf",
         "PyTorch": false,
         "TensorFlow": false,
+        "Item Graph": true,
+        "User Text": false,
+        "User Image": false,
+        "User Graph": false,
+        "Item Text": false,
+        "Item Image": false,
+        "Sentiment": false,
+        "Review Text": false,
+        "User Feature": false,
+        "Item Feature": false,
         "packages": [
             "cornac.models.MCF"
         ]
@@ -349,6 +609,16 @@ var data = [
         "paper": "https://arxiv.org/pdf/1708.05031.pdf",
         "PyTorch": true,
         "TensorFlow": true,
+        "User Text": false,
+        "User Image": false,
+        "User Graph": false,
+        "Item Text": false,
+        "Item Image": false,
+        "Item Graph": false,
+        "Sentiment": false,
+        "Review Text": false,
+        "User Feature": false,
+        "Item Feature": false,
         "packages": [
             "cornac.models.GMF",
             "cornac.models.MLP",
@@ -364,6 +634,16 @@ var data = [
         "paper": "https://arxiv.org/pdf/1708.05031.pdf",
         "PyTorch": true,
         "TensorFlow": true,
+        "User Text": false,
+        "User Image": false,
+        "User Graph": false,
+        "Item Text": false,
+        "Item Image": false,
+        "Item Graph": false,
+        "Sentiment": false,
+        "Review Text": false,
+        "User Feature": false,
+        "Item Feature": false,
         "packages": [
             "cornac.models.GMF",
             "cornac.models.MLP",
@@ -379,6 +659,16 @@ var data = [
         "paper": "http://www.hadylauw.com/publications/cikm17a.pdf",
         "PyTorch": true,
         "TensorFlow": false,
+        "User Text": false,
+        "User Image": false,
+        "User Graph": false,
+        "Item Text": false,
+        "Item Image": false,
+        "Item Graph": false,
+        "Sentiment": false,
+        "Review Text": false,
+        "User Feature": false,
+        "Item Feature": false,
         "packages": [
             "cornac.models.OnlineIBPR"
         ]
@@ -392,6 +682,16 @@ var data = [
         "paper": "https://dsail.kaist.ac.kr/files/WWW17.pdf",
         "PyTorch": true,
         "TensorFlow": false,
+        "Item Image": true,
+        "Item Feature": true,
+        "User Text": false,
+        "User Image": false,
+        "User Graph": false,
+        "Item Text": false,
+        "Item Graph": false,
+        "Sentiment": false,
+        "Review Text": false,
+        "User Feature": false,
         "packages": [
             "cornac.models.VMF"
         ]
@@ -405,6 +705,16 @@ var data = [
         "paper": "http://inpluslab.com/chenliang/homepagefiles/paper/hao-pakdd2016.pdf",
         "PyTorch": false,
         "TensorFlow": true,
+        "Item Text": true,
+        "User Text": false,
+        "User Image": false,
+        "User Graph": false,
+        "Item Image": false,
+        "Item Graph": false,
+        "Sentiment": false,
+        "Review Text": false,
+        "User Feature": false,
+        "Item Feature": false,
         "packages": [
             "cornac.models.CDR"
         ]
@@ -418,6 +728,16 @@ var data = [
         "paper": "http://www.hadylauw.com/publications/sdm16.pdf",
         "PyTorch": true,
         "TensorFlow": false,
+        "User Text": false,
+        "User Image": false,
+        "User Graph": false,
+        "Item Text": false,
+        "Item Image": false,
+        "Item Graph": false,
+        "Sentiment": false,
+        "Review Text": false,
+        "User Feature": false,
+        "Item Feature": false,
         "packages": [
             "cornac.models.COE"
         ]
@@ -431,6 +751,16 @@ var data = [
         "paper": "http://uclab.khu.ac.kr/resources/publication/C_351.pdf",
         "PyTorch": false,
         "TensorFlow": true,
+        "Item Text": true,
+        "User Text": false,
+        "User Image": false,
+        "User Graph": false,
+        "Item Image": false,
+        "Item Graph": false,
+        "Sentiment": false,
+        "Review Text": false,
+        "User Feature": false,
+        "Item Feature": false,
         "packages": [
             "cornac.models.ConvMF"
         ]
@@ -444,6 +774,16 @@ var data = [
         "paper": "https://www.yongfeng.me/attach/sigir16-chen.pdf",
         "PyTorch": false,
         "TensorFlow": false,
+        "User Text": false,
+        "User Image": false,
+        "User Graph": false,
+        "Item Text": false,
+        "Item Image": false,
+        "Item Graph": false,
+        "Sentiment": false,
+        "Review Text": false,
+        "User Feature": false,
+        "Item Feature": false,
         "packages": [
             "cornac.models.LRPPM"
         ]
@@ -457,6 +797,16 @@ var data = [
         "paper": "https://arxiv.org/pdf/1511.06939.pdf",
         "PyTorch": true,
         "TensorFlow": false,
+        "User Text": false,
+        "User Image": false,
+        "User Graph": false,
+        "Item Text": false,
+        "Item Image": false,
+        "Item Graph": false,
+        "Sentiment": false,
+        "Review Text": false,
+        "User Feature": false,
+        "Item Feature": false,
         "packages": [
             "cornac.models.GRU4Rec"
         ]
@@ -470,6 +820,16 @@ var data = [
         "paper": "https://www.sciencedirect.com/science/article/pii/S092523121501509X",
         "PyTorch": false,
         "TensorFlow": false,
+        "User Text": false,
+        "User Image": false,
+        "User Graph": false,
+        "Item Text": false,
+        "Item Image": false,
+        "Item Graph": false,
+        "Sentiment": false,
+        "Review Text": false,
+        "User Feature": false,
+        "Item Feature": false,
         "packages": [
             "cornac.models.SKMeans"
         ]
@@ -483,6 +843,16 @@ var data = [
         "paper": "https://arxiv.org/pdf/1510.01784.pdf",
         "PyTorch": true,
         "TensorFlow": false,
+        "Item Image": true,
+        "User Text": false,
+        "User Image": false,
+        "User Graph": false,
+        "Item Text": false,
+        "Item Graph": false,
+        "Sentiment": false,
+        "Review Text": false,
+        "User Feature": false,
+        "Item Feature": false,
         "packages": [
             "cornac.models.VBPR"
         ]
@@ -496,6 +866,16 @@ var data = [
         "paper": "https://arxiv.org/pdf/1409.2944.pdf",
         "PyTorch": false,
         "TensorFlow": true,
+        "Item Text": true,
+        "User Text": false,
+        "User Image": false,
+        "User Graph": false,
+        "Item Image": false,
+        "Item Graph": false,
+        "Sentiment": false,
+        "Review Text": false,
+        "User Feature": false,
+        "Item Feature": false,
         "packages": [
             "cornac.models.CDL"
         ]
@@ -509,6 +889,16 @@ var data = [
         "paper": "http://jakehofman.com/inprint/poisson_recs.pdf",
         "PyTorch": false,
         "TensorFlow": false,
+        "User Text": false,
+        "User Image": false,
+        "User Graph": false,
+        "Item Text": false,
+        "Item Image": false,
+        "Item Graph": false,
+        "Sentiment": false,
+        "Review Text": false,
+        "User Feature": false,
+        "Item Feature": false,
         "packages": [
             "cornac.models.HPF"
         ]
@@ -522,6 +912,16 @@ var data = [
         "paper": "https://wing.comp.nus.edu.sg/wp-content/uploads/Publications/PDF/TriRank-%20Review-aware%20Explainable%20Recommendation%20by%20Modeling%20Aspects.pdf",
         "PyTorch": false,
         "TensorFlow": false,
+        "Sentiment": true,
+        "User Text": false,
+        "User Image": false,
+        "User Graph": false,
+        "Item Text": false,
+        "Item Image": false,
+        "Item Graph": false,
+        "Review Text": false,
+        "User Feature": false,
+        "Item Feature": false,
         "packages": [
             "cornac.models.TriRank"
         ]
@@ -535,6 +935,16 @@ var data = [
         "paper": "https://www.yongfeng.me/attach/efm-zhang.pdf",
         "PyTorch": false,
         "TensorFlow": false,
+        "User Text": false,
+        "User Image": false,
+        "User Graph": false,
+        "Item Text": false,
+        "Item Image": false,
+        "Item Graph": false,
+        "Sentiment": false,
+        "Review Text": false,
+        "User Feature": false,
+        "Item Feature": false,
         "packages": [
             "cornac.models.EFM"
         ]
@@ -548,6 +958,16 @@ var data = [
         "paper": "https://cseweb.ucsd.edu/~jmcauley/pdfs/cikm14.pdf",
         "PyTorch": false,
         "TensorFlow": false,
+        "User Text": false,
+        "User Image": false,
+        "User Graph": false,
+        "Item Text": false,
+        "Item Image": false,
+        "Item Graph": false,
+        "Sentiment": false,
+        "Review Text": false,
+        "User Feature": false,
+        "Item Feature": false,
         "packages": [
             "cornac.models.SBPR"
         ]
@@ -561,6 +981,16 @@ var data = [
         "paper": "https://cs.stanford.edu/people/jure/pubs/reviews-recsys13.pdf",
         "PyTorch": false,
         "TensorFlow": false,
+        "Item Text": true,
+        "User Text": false,
+        "User Image": false,
+        "User Graph": false,
+        "Item Image": false,
+        "Item Graph": false,
+        "Sentiment": false,
+        "Review Text": false,
+        "User Feature": false,
+        "Item Feature": false,
         "packages": [
             "cornac.models.HFT"
         ]
@@ -574,6 +1004,16 @@ var data = [
         "paper": "http://proceedings.mlr.press/v18/gantner12a/gantner12a.pdf",
         "PyTorch": false,
         "TensorFlow": false,
+        "User Text": false,
+        "User Image": false,
+        "User Graph": false,
+        "Item Text": false,
+        "Item Image": false,
+        "Item Graph": false,
+        "Sentiment": false,
+        "Review Text": false,
+        "User Feature": false,
+        "Item Feature": false,
         "packages": [
             "cornac.models.BPR",
             "cornac.models.WBPR"
@@ -588,6 +1028,16 @@ var data = [
         "paper": "http://www.cs.columbia.edu/~blei/papers/WangBlei2011.pdf",
         "PyTorch": false,
         "TensorFlow": false,
+        "Item Text": true,
+        "User Text": false,
+        "User Image": false,
+        "User Graph": false,
+        "Item Image": false,
+        "Item Graph": false,
+        "Sentiment": false,
+        "Review Text": false,
+        "User Feature": false,
+        "Item Feature": false,
         "packages": [
             "cornac.models.CTR"
         ]
@@ -601,6 +1051,16 @@ var data = [
         "paper": "http://courses.ischool.berkeley.edu/i290-dm/s11/SECURE/a1-koren.pdf",
         "PyTorch": false,
         "TensorFlow": false,
+        "User Text": false,
+        "User Image": false,
+        "User Graph": false,
+        "Item Text": false,
+        "Item Image": false,
+        "Item Graph": false,
+        "Sentiment": false,
+        "Review Text": false,
+        "User Feature": false,
+        "Item Feature": false,
         "packages": [
             "cornac.models.BaselineOnly"
         ]
@@ -613,6 +1073,16 @@ var data = [
         "docs": "https://arxiv.org/ftp/arxiv/papers/1205/1205.2618.pdf",
         "PyTorch": false,
         "TensorFlow": false,
+        "User Text": false,
+        "User Image": false,
+        "User Graph": false,
+        "Item Text": false,
+        "Item Image": false,
+        "Item Graph": false,
+        "Sentiment": false,
+        "Review Text": false,
+        "User Feature": false,
+        "Item Feature": false,
         "packages": [
             "cornac.models.BPR",
             "cornac.models.WBPR"
@@ -627,6 +1097,16 @@ var data = [
         "paper": "https://www.csie.ntu.edu.tw/~b97053/paper/Factorization%20Machines%20with%20libFM.pdf",
         "PyTorch": false,
         "TensorFlow": false,
+        "User Text": false,
+        "User Image": false,
+        "User Graph": false,
+        "Item Text": false,
+        "Item Image": false,
+        "Item Graph": false,
+        "Sentiment": false,
+        "Review Text": false,
+        "User Feature": false,
+        "Item Feature": false,
         "packages": [
             "cornac.models.FM"
         ]
@@ -640,6 +1120,16 @@ var data = [
         "paper": "https://datajobs.com/data-science-repo/Recommender-Systems-[Netflix].pdf",
         "PyTorch": false,
         "TensorFlow": false,
+        "User Text": false,
+        "User Image": false,
+        "User Graph": false,
+        "Item Text": false,
+        "Item Image": false,
+        "Item Graph": false,
+        "Sentiment": false,
+        "Review Text": false,
+        "User Feature": false,
+        "Item Feature": false,
         "packages": [
             "cornac.models.GlobalAvg"
         ]
@@ -652,6 +1142,16 @@ var data = [
         "paper": "https://dl.acm.org/doi/pdf/10.1145/3587153",
         "PyTorch": false,
         "TensorFlow": false,
+        "User Text": false,
+        "User Image": false,
+        "User Graph": false,
+        "Item Text": false,
+        "Item Image": false,
+        "Item Graph": false,
+        "Sentiment": false,
+        "Review Text": false,
+        "User Feature": false,
+        "Item Feature": false,
         "packages": [
             "cornac.models.GPTop"
         ]
@@ -665,6 +1165,16 @@ var data = [
         "paper": "https://dl.acm.org/doi/pdf/10.1145/371920.372071",
         "PyTorch": false,
         "TensorFlow": false,
+        "User Text": false,
+        "User Image": false,
+        "User Graph": false,
+        "Item Text": false,
+        "Item Image": false,
+        "Item Graph": false,
+        "Sentiment": false,
+        "Review Text": false,
+        "User Feature": false,
+        "Item Feature": false,
         "packages": [
             "cornac.models.ItemKNN",
             "cornac.models.UserKNN"
@@ -679,6 +1189,16 @@ var data = [
         "paper": "https://datajobs.com/data-science-repo/Recommender-Systems-[Netflix].pdf",
         "PyTorch": false,
         "TensorFlow": false,
+        "User Text": false,
+        "User Image": false,
+        "User Graph": false,
+        "Item Text": false,
+        "Item Image": false,
+        "Item Graph": false,
+        "Sentiment": false,
+        "Review Text": false,
+        "User Feature": false,
+        "Item Feature": false,
         "packages": [
             "cornac.models.MF"
         ]
@@ -692,6 +1212,16 @@ var data = [
         "paper": "https://link.springer.com/content/pdf/10.1007/s10994-008-5073-7.pdf",
         "PyTorch": false,
         "TensorFlow": false,
+        "User Text": false,
+        "User Image": false,
+        "User Graph": false,
+        "Item Text": false,
+        "Item Image": false,
+        "Item Graph": false,
+        "Sentiment": false,
+        "Review Text": false,
+        "User Feature": false,
+        "Item Feature": false,
         "packages": [
             "cornac.models.MMMF"
         ]
@@ -705,6 +1235,16 @@ var data = [
         "paper": "https://arxiv.org/ftp/arxiv/papers/1205/1205.2618.pdf",
         "PyTorch": false,
         "TensorFlow": false,
+        "User Text": false,
+        "User Image": false,
+        "User Graph": false,
+        "Item Text": false,
+        "Item Image": false,
+        "Item Graph": false,
+        "Sentiment": false,
+        "Review Text": false,
+        "User Feature": false,
+        "Item Feature": false,
         "packages": [
             "cornac.models.MostPop"
         ]
@@ -718,6 +1258,16 @@ var data = [
         "paper": "http://papers.nips.cc/paper/1861-algorithms-for-non-negative-matrix-factorization.pdf",
         "PyTorch": false,
         "TensorFlow": false,
+        "User Text": false,
+        "User Image": false,
+        "User Graph": false,
+        "Item Text": false,
+        "Item Image": false,
+        "Item Graph": false,
+        "Sentiment": false,
+        "Review Text": false,
+        "User Feature": false,
+        "Item Feature": false,
         "packages": [
             "cornac.models.NMF"
         ]
@@ -731,6 +1281,16 @@ var data = [
         "paper": "https://papers.nips.cc/paper/3208-probabilistic-matrix-factorization.pdf",
         "PyTorch": false,
         "TensorFlow": false,
+        "User Text": false,
+        "User Image": false,
+        "User Graph": false,
+        "Item Text": false,
+        "Item Image": false,
+        "Item Graph": false,
+        "Sentiment": false,
+        "Review Text": false,
+        "User Feature": false,
+        "Item Feature": false,
         "packages": [
             "cornac.models.PMF"
         ]
@@ -744,6 +1304,16 @@ var data = [
         "paper": "https://arxiv.org/pdf/1511.06939.pdf",
         "PyTorch": false,
         "TensorFlow": false,
+        "User Text": false,
+        "User Image": false,
+        "User Graph": false,
+        "Item Text": false,
+        "Item Image": false,
+        "Item Graph": false,
+        "Sentiment": false,
+        "Review Text": false,
+        "User Feature": false,
+        "Item Feature": false,
         "packages": [
             "cornac.models.SPop"
         ]
@@ -757,6 +1327,16 @@ var data = [
         "paper": "https://people.engr.tamu.edu/huangrh/Spring16/papers_course/matrix_factorization.pdf",
         "PyTorch": false,
         "TensorFlow": false,
+        "User Text": false,
+        "User Image": false,
+        "User Graph": false,
+        "Item Text": false,
+        "Item Image": false,
+        "Item Graph": false,
+        "Sentiment": false,
+        "Review Text": false,
+        "User Feature": false,
+        "Item Feature": false,
         "packages": [
             "cornac.models.SVD"
         ]
@@ -770,6 +1350,16 @@ var data = [
         "paper": "http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.304.2464&rep=rep1&type=pdf",
         "PyTorch": false,
         "TensorFlow": false,
+        "User Graph": true,
+        "User Text": false,
+        "User Image": false,
+        "Item Text": false,
+        "Item Image": false,
+        "Item Graph": false,
+        "Sentiment": false,
+        "Review Text": false,
+        "User Feature": false,
+        "Item Feature": false,
         "packages": [
             "cornac.models.SoRec"
         ]
@@ -783,6 +1373,16 @@ var data = [
         "paper": "https://arxiv.org/pdf/1301.7363.pdf",
         "PyTorch": false,
         "TensorFlow": false,
+        "User Text": false,
+        "User Image": false,
+        "User Graph": false,
+        "Item Text": false,
+        "Item Image": false,
+        "Item Graph": false,
+        "Sentiment": false,
+        "Review Text": false,
+        "User Feature": false,
+        "Item Feature": false,
         "packages": [
             "cornac.models.ItemKNN",
             "cornac.models.UserKNN"
@@ -797,6 +1397,16 @@ var data = [
         "paper": "http://yifanhu.net/PUB/cf.pdf",
         "PyTorch": false,
         "TensorFlow": true,
+        "User Text": false,
+        "User Image": false,
+        "User Graph": false,
+        "Item Text": false,
+        "Item Image": false,
+        "Item Graph": false,
+        "Sentiment": false,
+        "Review Text": false,
+        "User Feature": false,
+        "Item Feature": false,
         "packages": [
             "cornac.models.WMF"
         ]

--- a/docs/source/_static/models/data.js
+++ b/docs/source/_static/models/data.js
@@ -16,8 +16,6 @@ var data = [
         "Item Text": false,
         "Item Image": false,
         "Item Graph": false,
-        "User Feature": false,
-        "Item Feature": false,
         "packages": [
             "cornac.models.HypAR"
         ]
@@ -39,8 +37,6 @@ var data = [
         "Item Graph": false,
         "Sentiment": false,
         "Review Text": false,
-        "User Feature": false,
-        "Item Feature": false,
         "packages": [
             "cornac.models.DMRL"
         ]
@@ -54,14 +50,12 @@ var data = [
         "paper": "https://dl.acm.org/doi/pdf/10.1145/3437963.3441759",
         "PyTorch": true,
         "TensorFlow": false,
-        "User Feature": true,
-        "Item Feature": true,
-        "User Text": false,
-        "User Image": false,
-        "User Graph": false,
-        "Item Text": false,
-        "Item Image": false,
-        "Item Graph": false,
+        "User Text": true,
+        "User Image": true,
+        "User Graph": true,
+        "Item Text": true,
+        "Item Image": true,
+        "Item Graph": true,
         "Sentiment": false,
         "Review Text": false,
         "packages": [
@@ -85,8 +79,6 @@ var data = [
         "Item Graph": false,
         "Sentiment": false,
         "Review Text": false,
-        "User Feature": false,
-        "Item Feature": false,
         "packages": [
             "cornac.models.CausalRec"
         ]
@@ -108,8 +100,6 @@ var data = [
         "Item Graph": false,
         "Sentiment": false,
         "Review Text": false,
-        "User Feature": false,
-        "Item Feature": false,
         "packages": [
             "cornac.models.ComparERSub",
             "cornac.models.ComparERObj"
@@ -132,8 +122,6 @@ var data = [
         "Item Graph": false,
         "Sentiment": false,
         "Review Text": false,
-        "User Feature": false,
-        "Item Feature": false,
         "packages": [
             "cornac.models.AMR"
         ]
@@ -155,8 +143,6 @@ var data = [
         "Item Image": false,
         "Item Graph": false,
         "Sentiment": false,
-        "User Feature": false,
-        "Item Feature": false,
         "packages": [
             "cornac.models.HRDR"
         ]
@@ -178,8 +164,6 @@ var data = [
         "Item Graph": false,
         "Sentiment": false,
         "Review Text": false,
-        "User Feature": false,
-        "Item Feature": false,
         "packages": [
             "cornac.models.LightGCN"
         ]
@@ -201,8 +185,6 @@ var data = [
         "Item Graph": false,
         "Sentiment": false,
         "Review Text": false,
-        "User Feature": false,
-        "Item Feature": false,
         "packages": [
             "cornac.models.DNNTSP"
         ]
@@ -224,8 +206,6 @@ var data = [
         "Item Graph": false,
         "Sentiment": false,
         "Review Text": false,
-        "User Feature": false,
-        "Item Feature": false,
         "packages": [
             "cornac.models.UPCF"
         ]
@@ -247,8 +227,6 @@ var data = [
         "Item Graph": false,
         "Sentiment": false,
         "Review Text": false,
-        "User Feature": false,
-        "Item Feature": false,
         "packages": [
             "cornac.models.TIFUKNN"
         ]
@@ -270,8 +248,6 @@ var data = [
         "Item Graph": false,
         "Sentiment": false,
         "Review Text": false,
-        "User Feature": false,
-        "Item Feature": false,
         "packages": [
             "cornac.models.RecVAE"
         ]
@@ -293,8 +269,6 @@ var data = [
         "Item Graph": false,
         "Sentiment": false,
         "Review Text": false,
-        "User Feature": false,
-        "Item Feature": false,
         "packages": [
             "cornac.models.Beacon"
         ]
@@ -316,8 +290,6 @@ var data = [
         "Item Graph": false,
         "Sentiment": false,
         "Review Text": false,
-        "User Feature": false,
-        "Item Feature": false,
         "packages": [
             "cornac.models.EASE"
         ]
@@ -339,8 +311,6 @@ var data = [
         "Item Graph": false,
         "Sentiment": false,
         "Review Text": false,
-        "User Feature": false,
-        "Item Feature": false,
         "packages": [
             "cornac.models.NGCF"
         ]
@@ -362,8 +332,6 @@ var data = [
         "Item Image": false,
         "Sentiment": false,
         "Review Text": false,
-        "User Feature": false,
-        "Item Feature": false,
         "packages": [
             "cornac.models.C2PF"
         ]
@@ -385,8 +353,6 @@ var data = [
         "Item Graph": false,
         "Sentiment": false,
         "Review Text": false,
-        "User Feature": false,
-        "Item Feature": false,
         "packages": [
             "cornac.models.GCMC"
         ]
@@ -408,8 +374,6 @@ var data = [
         "Item Graph": false,
         "Sentiment": false,
         "Review Text": false,
-        "User Feature": false,
-        "Item Feature": false,
         "packages": [
             "cornac.models.MTER"
         ]
@@ -431,8 +395,6 @@ var data = [
         "Item Image": false,
         "Item Graph": false,
         "Sentiment": false,
-        "User Feature": false,
-        "Item Feature": false,
         "packages": [
             "cornac.models.NARRE"
         ]
@@ -454,8 +416,6 @@ var data = [
         "Item Image": false,
         "Sentiment": false,
         "Review Text": false,
-        "User Feature": false,
-        "Item Feature": false,
         "packages": [
             "cornac.models.PCRL"
         ]
@@ -477,8 +437,6 @@ var data = [
         "Item Graph": false,
         "Sentiment": false,
         "Review Text": false,
-        "User Feature": false,
-        "Item Feature": false,
         "packages": [
             "cornac.models.VAECF"
         ]
@@ -500,8 +458,6 @@ var data = [
         "Item Graph": false,
         "Sentiment": false,
         "Review Text": false,
-        "User Feature": false,
-        "Item Feature": false,
         "packages": [
             "cornac.models.CVAE"
         ]
@@ -523,8 +479,6 @@ var data = [
         "Item Graph": false,
         "Sentiment": false,
         "Review Text": false,
-        "User Feature": false,
-        "Item Feature": false,
         "packages": [
             "cornac.models.CVAECF"
         ]
@@ -546,8 +500,6 @@ var data = [
         "Item Graph": false,
         "Sentiment": false,
         "Review Text": false,
-        "User Feature": false,
-        "Item Feature": false,
         "packages": [
             "cornac.models.GMF",
             "cornac.models.MLP",
@@ -571,8 +523,6 @@ var data = [
         "Item Graph": false,
         "Sentiment": false,
         "Review Text": false,
-        "User Feature": false,
-        "Item Feature": false,
         "packages": [
             "cornac.models.IBPR"
         ]
@@ -594,8 +544,6 @@ var data = [
         "Item Image": false,
         "Sentiment": false,
         "Review Text": false,
-        "User Feature": false,
-        "Item Feature": false,
         "packages": [
             "cornac.models.MCF"
         ]
@@ -617,8 +565,6 @@ var data = [
         "Item Graph": false,
         "Sentiment": false,
         "Review Text": false,
-        "User Feature": false,
-        "Item Feature": false,
         "packages": [
             "cornac.models.GMF",
             "cornac.models.MLP",
@@ -642,8 +588,6 @@ var data = [
         "Item Graph": false,
         "Sentiment": false,
         "Review Text": false,
-        "User Feature": false,
-        "Item Feature": false,
         "packages": [
             "cornac.models.GMF",
             "cornac.models.MLP",
@@ -667,8 +611,6 @@ var data = [
         "Item Graph": false,
         "Sentiment": false,
         "Review Text": false,
-        "User Feature": false,
-        "Item Feature": false,
         "packages": [
             "cornac.models.OnlineIBPR"
         ]
@@ -683,15 +625,13 @@ var data = [
         "PyTorch": true,
         "TensorFlow": false,
         "Item Image": true,
-        "Item Feature": true,
+        "Item Text": true,
+        "Item Graph": true,
         "User Text": false,
         "User Image": false,
         "User Graph": false,
-        "Item Text": false,
-        "Item Graph": false,
         "Sentiment": false,
         "Review Text": false,
-        "User Feature": false,
         "packages": [
             "cornac.models.VMF"
         ]
@@ -713,8 +653,6 @@ var data = [
         "Item Graph": false,
         "Sentiment": false,
         "Review Text": false,
-        "User Feature": false,
-        "Item Feature": false,
         "packages": [
             "cornac.models.CDR"
         ]
@@ -736,8 +674,6 @@ var data = [
         "Item Graph": false,
         "Sentiment": false,
         "Review Text": false,
-        "User Feature": false,
-        "Item Feature": false,
         "packages": [
             "cornac.models.COE"
         ]
@@ -759,8 +695,6 @@ var data = [
         "Item Graph": false,
         "Sentiment": false,
         "Review Text": false,
-        "User Feature": false,
-        "Item Feature": false,
         "packages": [
             "cornac.models.ConvMF"
         ]
@@ -782,8 +716,6 @@ var data = [
         "Item Graph": false,
         "Sentiment": false,
         "Review Text": false,
-        "User Feature": false,
-        "Item Feature": false,
         "packages": [
             "cornac.models.LRPPM"
         ]
@@ -805,8 +737,6 @@ var data = [
         "Item Graph": false,
         "Sentiment": false,
         "Review Text": false,
-        "User Feature": false,
-        "Item Feature": false,
         "packages": [
             "cornac.models.GRU4Rec"
         ]
@@ -828,8 +758,6 @@ var data = [
         "Item Graph": false,
         "Sentiment": false,
         "Review Text": false,
-        "User Feature": false,
-        "Item Feature": false,
         "packages": [
             "cornac.models.SKMeans"
         ]
@@ -851,8 +779,6 @@ var data = [
         "Item Graph": false,
         "Sentiment": false,
         "Review Text": false,
-        "User Feature": false,
-        "Item Feature": false,
         "packages": [
             "cornac.models.VBPR"
         ]
@@ -874,8 +800,6 @@ var data = [
         "Item Graph": false,
         "Sentiment": false,
         "Review Text": false,
-        "User Feature": false,
-        "Item Feature": false,
         "packages": [
             "cornac.models.CDL"
         ]
@@ -897,8 +821,6 @@ var data = [
         "Item Graph": false,
         "Sentiment": false,
         "Review Text": false,
-        "User Feature": false,
-        "Item Feature": false,
         "packages": [
             "cornac.models.HPF"
         ]
@@ -920,8 +842,6 @@ var data = [
         "Item Image": false,
         "Item Graph": false,
         "Review Text": false,
-        "User Feature": false,
-        "Item Feature": false,
         "packages": [
             "cornac.models.TriRank"
         ]
@@ -943,8 +863,6 @@ var data = [
         "Item Graph": false,
         "Sentiment": false,
         "Review Text": false,
-        "User Feature": false,
-        "Item Feature": false,
         "packages": [
             "cornac.models.EFM"
         ]
@@ -966,8 +884,6 @@ var data = [
         "Item Graph": false,
         "Sentiment": false,
         "Review Text": false,
-        "User Feature": false,
-        "Item Feature": false,
         "packages": [
             "cornac.models.SBPR"
         ]
@@ -989,8 +905,6 @@ var data = [
         "Item Graph": false,
         "Sentiment": false,
         "Review Text": false,
-        "User Feature": false,
-        "Item Feature": false,
         "packages": [
             "cornac.models.HFT"
         ]
@@ -1012,8 +926,6 @@ var data = [
         "Item Graph": false,
         "Sentiment": false,
         "Review Text": false,
-        "User Feature": false,
-        "Item Feature": false,
         "packages": [
             "cornac.models.BPR",
             "cornac.models.WBPR"
@@ -1036,8 +948,6 @@ var data = [
         "Item Graph": false,
         "Sentiment": false,
         "Review Text": false,
-        "User Feature": false,
-        "Item Feature": false,
         "packages": [
             "cornac.models.CTR"
         ]
@@ -1059,8 +969,6 @@ var data = [
         "Item Graph": false,
         "Sentiment": false,
         "Review Text": false,
-        "User Feature": false,
-        "Item Feature": false,
         "packages": [
             "cornac.models.BaselineOnly"
         ]
@@ -1081,8 +989,6 @@ var data = [
         "Item Graph": false,
         "Sentiment": false,
         "Review Text": false,
-        "User Feature": false,
-        "Item Feature": false,
         "packages": [
             "cornac.models.BPR",
             "cornac.models.WBPR"
@@ -1105,8 +1011,6 @@ var data = [
         "Item Graph": false,
         "Sentiment": false,
         "Review Text": false,
-        "User Feature": false,
-        "Item Feature": false,
         "packages": [
             "cornac.models.FM"
         ]
@@ -1128,8 +1032,6 @@ var data = [
         "Item Graph": false,
         "Sentiment": false,
         "Review Text": false,
-        "User Feature": false,
-        "Item Feature": false,
         "packages": [
             "cornac.models.GlobalAvg"
         ]
@@ -1150,8 +1052,6 @@ var data = [
         "Item Graph": false,
         "Sentiment": false,
         "Review Text": false,
-        "User Feature": false,
-        "Item Feature": false,
         "packages": [
             "cornac.models.GPTop"
         ]
@@ -1173,8 +1073,6 @@ var data = [
         "Item Graph": false,
         "Sentiment": false,
         "Review Text": false,
-        "User Feature": false,
-        "Item Feature": false,
         "packages": [
             "cornac.models.ItemKNN",
             "cornac.models.UserKNN"
@@ -1197,8 +1095,6 @@ var data = [
         "Item Graph": false,
         "Sentiment": false,
         "Review Text": false,
-        "User Feature": false,
-        "Item Feature": false,
         "packages": [
             "cornac.models.MF"
         ]
@@ -1220,8 +1116,6 @@ var data = [
         "Item Graph": false,
         "Sentiment": false,
         "Review Text": false,
-        "User Feature": false,
-        "Item Feature": false,
         "packages": [
             "cornac.models.MMMF"
         ]
@@ -1243,8 +1137,6 @@ var data = [
         "Item Graph": false,
         "Sentiment": false,
         "Review Text": false,
-        "User Feature": false,
-        "Item Feature": false,
         "packages": [
             "cornac.models.MostPop"
         ]
@@ -1266,8 +1158,6 @@ var data = [
         "Item Graph": false,
         "Sentiment": false,
         "Review Text": false,
-        "User Feature": false,
-        "Item Feature": false,
         "packages": [
             "cornac.models.NMF"
         ]
@@ -1289,8 +1179,6 @@ var data = [
         "Item Graph": false,
         "Sentiment": false,
         "Review Text": false,
-        "User Feature": false,
-        "Item Feature": false,
         "packages": [
             "cornac.models.PMF"
         ]
@@ -1312,8 +1200,6 @@ var data = [
         "Item Graph": false,
         "Sentiment": false,
         "Review Text": false,
-        "User Feature": false,
-        "Item Feature": false,
         "packages": [
             "cornac.models.SPop"
         ]
@@ -1335,8 +1221,6 @@ var data = [
         "Item Graph": false,
         "Sentiment": false,
         "Review Text": false,
-        "User Feature": false,
-        "Item Feature": false,
         "packages": [
             "cornac.models.SVD"
         ]
@@ -1358,8 +1242,6 @@ var data = [
         "Item Graph": false,
         "Sentiment": false,
         "Review Text": false,
-        "User Feature": false,
-        "Item Feature": false,
         "packages": [
             "cornac.models.SoRec"
         ]
@@ -1381,8 +1263,6 @@ var data = [
         "Item Graph": false,
         "Sentiment": false,
         "Review Text": false,
-        "User Feature": false,
-        "Item Feature": false,
         "packages": [
             "cornac.models.ItemKNN",
             "cornac.models.UserKNN"
@@ -1405,8 +1285,6 @@ var data = [
         "Item Graph": false,
         "Sentiment": false,
         "Review Text": false,
-        "User Feature": false,
-        "Item Feature": false,
         "packages": [
             "cornac.models.WMF"
         ]

--- a/docs/source/_static/models/models.html
+++ b/docs/source/_static/models/models.html
@@ -127,12 +127,12 @@
             { 
                 field: "PyTorch", 
                 headerName: "PyTorch",
-                cellRenderer: params => params.value ? "✅" : "❌",
+                cellRenderer: params => params.value ? "✅" : "",
             },
             { 
                 field: "TensorFlow",
                 headerName: "TensorFlow",
-                cellRenderer: params => params.value ? "✅" : "❌",
+                cellRenderer: params => params.value ? "✅" : "",
             },
         ],
         defaultColDef: {

--- a/docs/source/_static/models/models_modalities.html
+++ b/docs/source/_static/models/models_modalities.html
@@ -1,0 +1,128 @@
+<html lang="en">
+ <head>
+   <script src="https://cdn.jsdelivr.net/npm/ag-grid-community/dist/ag-grid-community.min.js"></script>
+ </head>
+ <body>
+    <h3>Models with Modalities</h3>
+    <br />
+    <div id="modalityGrid" class="ag-theme-quartz-auto-dark" style="height: 500px"></div>
+ </body>
+</html>
+<script type="text/javascript" src="data.js"></script>
+<script type="text/javascript" src="../_static/models/data.js"></script>
+<script type="text/javascript" src="_static/models/data.js"></script>
+<script type="text/javascript">
+    function LinkRenderer(url, title) {
+        return `<a href="${url}" target="_blank">${title}</a>`
+    }
+    // Grid API: Access to Grid API methods
+    let modalityGridApi;
+
+    // Grid Options: Contains all of the grid configurations
+    const modalityGridOptions = {
+        // Data to be displayed
+        rowData: data,
+        // Columns to be displayed (Should match rowData properties)
+        columnDefs: [
+            { field: "Year" },
+            { 
+                field: "Name",
+                headerName: "Model Name (Hover over for package name)",
+                
+                flex: 4,
+                cellRenderer: params => LinkRenderer(params.data.docs, params.data.Name),
+                tooltipValueGetter: (params) => "Package Name: " + params.data.packages,
+            },
+            {
+                headerName: "Text",
+                children: [
+                    {
+                        field: "User Text",
+                        headerName: "User",
+                        cellRenderer: params => params.value ? "✅" : "❌",
+                    },
+                    {
+                        field: "Item Text",
+                        headerName: "Item",
+                        cellRenderer: params => params.value ? "✅" : "❌",
+                    },
+                ]
+            },
+            {
+                headerName: "Image",
+                children: [
+                    {
+                        field: "User Image",
+                        headerName: "User",
+                        cellRenderer: params => params.value ? "✅" : "❌",
+                    },
+                    {
+                        field: "Item Image",
+                        headerName: "Item",
+                        cellRenderer: params => params.value ? "✅" : "❌",
+                    },
+                ]
+            },
+            {
+                headerName: "Graph",
+                children: [
+                    {
+                        field: "User Graph",
+                        headerName: "User",
+                        cellRenderer: params => params.value ? "✅" : "❌",
+                    },
+                    {
+                        field: "Item Graph",
+                        headerName: "Item",
+                        cellRenderer: params => params.value ? "✅" : "❌",
+                    },
+                ]
+            },
+            {
+                field: "Sentiment",
+                headerName: "Sentiment",
+                cellRenderer: params => params.value ? "✅" : "❌",
+            },
+            {
+                field: "Review Text",
+                headerName: "Review Text",
+                cellRenderer: params => params.value ? "✅" : "❌",
+            },
+            {
+                "headerName": "Feature",
+                children: [
+                    {
+                        field: "User Feature",
+                        headerName: "User",
+                        cellRenderer: params => params.value ? "✅" : "❌",
+                    },
+                    {
+                        field: "Item Feature",
+                        headerName: "Item",
+                        cellRenderer: params => params.value ? "✅" : "❌",
+                    },
+                ]
+            },
+        ],
+        defaultColDef: {
+            flex: 1,
+            filter: true,
+            // floatingFilter: true,
+        },
+        pagination: true,
+        paginationAutoPageSize: true
+    };
+    // Create Grid: Create new grid within the #myGrid div, using the Grid Options object
+    modalityGridApi = agGrid.createGrid(document.querySelector("#modalityGrid"), modalityGridOptions);
+</script>
+
+<style>
+    /* Make h2 bigger */
+    .bd-page-width {
+        width: 100%;
+    }
+    .bd-main .bd-content .bd-article-container {
+        max-width: 100%;  /* default is 60em */
+    }
+</style>
+

--- a/docs/source/_static/models/models_modalities.html
+++ b/docs/source/_static/models/models_modalities.html
@@ -39,12 +39,12 @@
                     {
                         field: "User Text",
                         headerName: "User",
-                        cellRenderer: params => params.value ? "✅" : "❌",
+                        cellRenderer: params => params.value ? "✅" : "",
                     },
                     {
                         field: "Item Text",
                         headerName: "Item",
-                        cellRenderer: params => params.value ? "✅" : "❌",
+                        cellRenderer: params => params.value ? "✅" : "",
                     },
                 ]
             },
@@ -54,12 +54,12 @@
                     {
                         field: "User Image",
                         headerName: "User",
-                        cellRenderer: params => params.value ? "✅" : "❌",
+                        cellRenderer: params => params.value ? "✅" : "",
                     },
                     {
                         field: "Item Image",
                         headerName: "Item",
-                        cellRenderer: params => params.value ? "✅" : "❌",
+                        cellRenderer: params => params.value ? "✅" : "",
                     },
                 ]
             },
@@ -69,39 +69,24 @@
                     {
                         field: "User Graph",
                         headerName: "User",
-                        cellRenderer: params => params.value ? "✅" : "❌",
+                        cellRenderer: params => params.value ? "✅" : "",
                     },
                     {
                         field: "Item Graph",
                         headerName: "Item",
-                        cellRenderer: params => params.value ? "✅" : "❌",
+                        cellRenderer: params => params.value ? "✅" : "",
                     },
                 ]
             },
             {
                 field: "Sentiment",
                 headerName: "Sentiment",
-                cellRenderer: params => params.value ? "✅" : "❌",
+                cellRenderer: params => params.value ? "✅" : "",
             },
             {
                 field: "Review Text",
                 headerName: "Review Text",
-                cellRenderer: params => params.value ? "✅" : "❌",
-            },
-            {
-                "headerName": "Feature",
-                children: [
-                    {
-                        field: "User Feature",
-                        headerName: "User",
-                        cellRenderer: params => params.value ? "✅" : "❌",
-                    },
-                    {
-                        field: "Item Feature",
-                        headerName: "Item",
-                        cellRenderer: params => params.value ? "✅" : "❌",
-                    },
-                ]
+                cellRenderer: params => params.value ? "✅" : "",
             },
         ],
         defaultColDef: {

--- a/docs/source/_static/models/models_modalities.html
+++ b/docs/source/_static/models/models_modalities.html
@@ -109,5 +109,10 @@
     .bd-main .bd-content .bd-article-container {
         max-width: 100%;  /* default is 60em */
     }
+
+    .ag-theme-quartz-auto-dark {
+        /* add border between cell columns */
+        --ag-cell-horizontal-border: solid rgb(230, 230, 230);
+    }
 </style>
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -108,8 +108,8 @@ html_theme_options = {
 }
 
 html_sidebars = {
-  "models/index": [],
-  "index": [],
+    "models/index": [],
+    "index": [],
 }
 
 # -- Options for intersphinx extension ---------------------------------------

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -100,6 +100,14 @@ html_theme_options = {
     },
     "pygment_light_style": "default",
     "pygment_dark_style": "github-dark",
+    "secondary_sidebar_items": {
+        "models/index": [],
+    },
+}
+
+html_sidebars = {
+  "models/index": [],
+  "index": [],
 }
 
 # -- Options for intersphinx extension ---------------------------------------

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -101,8 +101,10 @@ html_theme_options = {
     "pygment_light_style": "default",
     "pygment_dark_style": "github-dark",
     "secondary_sidebar_items": {
+        "**": ["page-toc", "sourcelink"],
+        "index": [],
         "models/index": [],
-    },
+    }
 }
 
 html_sidebars = {

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -115,3 +115,11 @@ Quick Links
          :click-parent:
 
          Contributor's Guide
+
+.. raw:: html
+
+    <style>
+      .bd-main .bd-content .bd-article-container {
+        max-width: 100%;
+      }
+    </style>

--- a/docs/source/models/index.rst
+++ b/docs/source/models/index.rst
@@ -6,3 +6,6 @@ Clicking on the model name will take you to the model's API documentation.
 
 .. raw:: html
    :file: ../_static/models/models.html
+
+.. raw:: html
+   :file: ../_static/models/models_modalities.html


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
This PR adds an additional table below the existing model table in readthedocs, showing the modality each model supports.
Also, layout of page is widened to support more content in tables.

An preview of the table is as follows:
![image](https://github.com/user-attachments/assets/63fe2c69-46f8-414c-a167-4299185bc6e7)



### Related Issues
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #634 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have added tests.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated `README.md` (if you are adding a new model).
- [ ] I have updated `examples/README.md` (if you are adding a new example).
- [ ] I have updated `datasets/README.md` (if you are adding a new dataset).
