### PR TITLE
#641 Fix BiVAECF expected dense matrix

### DIFF
--- a/cornac/models/bivaecf/bivae.py
+++ b/cornac/models/bivaecf/bivae.py
@@ -198,7 +198,7 @@ def learn(
         i_count = 0
         for i_ids in train_set.item_iter(batch_size, shuffle=False):
             i_batch = tx[i_ids, :]
-            i_batch = i_batch.A
+            i_batch = i_batch.todense().A
             i_batch = torch.tensor(i_batch, dtype=dtype, device=device)
 
             # Reconstructed batch
@@ -228,7 +228,7 @@ def learn(
         u_count = 0
         for u_ids in train_set.user_iter(batch_size, shuffle=False):
             u_batch = x[u_ids, :]
-            u_batch = u_batch.A
+            u_batch = u_batch.todense().A
             u_batch = torch.tensor(u_batch, dtype=dtype, device=device)
 
             # Reconstructed batch
@@ -259,7 +259,7 @@ def learn(
     # infer mu_beta
     for i_ids in train_set.item_iter(batch_size, shuffle=False):
         i_batch = tx[i_ids, :]
-        i_batch = i_batch.A
+        i_batch = i_batch.todense().A
         i_batch = torch.tensor(i_batch, dtype=dtype, device=device)
 
         beta, _, i_mu, _ = bivae(i_batch, user=False, theta=bivae.theta)
@@ -268,7 +268,7 @@ def learn(
     # infer mu_theta
     for u_ids in train_set.user_iter(batch_size, shuffle=False):
         u_batch = x[u_ids, :]
-        u_batch = u_batch.A
+        u_batch = u_batch.todense().A
         u_batch = torch.tensor(u_batch, dtype=dtype, device=device)
 
         theta, _, u_mu, _ = bivae(u_batch, user=True, beta=bivae.beta)

--- a/tests/cornac/models/bivae/test_recommender.py
+++ b/tests/cornac/models/bivae/test_recommender.py
@@ -1,0 +1,15 @@
+import unittest
+
+from cornac.data import Dataset, Reader
+from cornac.models import BiVAECF
+
+
+class TestRecommender(unittest.TestCase):
+    def setUp(self):
+        self.data = Reader().read("./tests/data.txt")
+
+    def test_run(self):
+        bivae = BiVAECF(k=1, seed=123)
+        dataset = Dataset.from_uir(self.data)
+        # Assert runs without error
+        bivae.fit(dataset)


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
Prevent BiVAE from failing due to error `'csc_matrix' object has no attribute 'A'`.

### Related Issues
<!--- If it fixes an open issue, please link to the issue here. -->
Fix #641 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added tests.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated `README.md` (if you are adding a new model).
- [ ] I have updated `examples/README.md` (if you are adding a new example).
- [ ] I have updated `datasets/README.md` (if you are adding a new dataset).
