### PR TITLE
Replace GitHub Actions macos versions to just macos-latest

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-latest, ubuntu-latest, macos-13, macos-14]
+        os: [windows-latest, ubuntu-latest, macos-latest]
         python-version: ["3.9", "3.10", "3.11", "3.12"]
     env:
       LIMIT_NUMPY_VERSION: 2.0.0
@@ -29,7 +29,7 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Setup Python ${{ matrix.python-version }}
-      if: ${{ (matrix.os != 'macos-14') || ((matrix.os == 'macos-14') && (matrix.python-version != '3.9')) }}
+      if: ${{ ((matrix.os == 'macos-latest') && (matrix.python-version != '3.9')) }}
       uses: actions/setup-python@v5
       id: pysetup
       with:
@@ -37,7 +37,7 @@ jobs:
         cache: 'pip'
 
     - name: Setup Python 3.9 - macos-arm
-      if: ${{ (matrix.os == 'macos-14') && (matrix.python-version == '3.9') }}
+      if: ${{ (matrix.os == 'macos-latest') && (matrix.python-version == '3.9') }}
       run: |
         brew update
         brew install python@${{ matrix.python-version }}

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -23,13 +23,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-latest, ubuntu-latest, macos-13, macos-14]
+        os: [windows-latest, ubuntu-latest, macos-latest]
         python-version: ["3.9", "3.10", "3.11", "3.12"]
     steps:
     - uses: actions/checkout@v4
     
     - name: Setup Python ${{ matrix.python-version }}
-      if: ${{ (matrix.os != 'macos-14') || ((matrix.os == 'macos-14') && (matrix.python-version != '3.9')) }}
+      if: ${{ ((matrix.os == 'macos-latest') && (matrix.python-version != '3.9')) }}
       uses: actions/setup-python@v5
       id: pysetup
       with:
@@ -37,7 +37,7 @@ jobs:
         cache: 'pip'
 
     - name: Setup Python 3.9 - macos-arm
-      if: ${{ (matrix.os == 'macos-14') && (matrix.python-version == '3.9') }}
+      if: ${{ (matrix.os == 'macos-latest') && (matrix.python-version == '3.9') }}
       run: |
         brew update
         brew install python@${{ matrix.python-version }}
@@ -118,7 +118,7 @@ jobs:
       with:
         user: __token__
         password: ${{ secrets.PYPI_API_TOKEN }}
-        packages_dir: ./dist/
-        verify_metadata: false
-        skip_existing: true
+        packages-dir: ./dist/
+        verify-metadata: false
+        skip-existing: true
         verbose: true


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
In this PR, we change macOS builds in GitHub Actions to only utilise single macOS-latest builds.

### Related Issues
<!--- If it fixes an open issue, please link to the issue here. -->


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have added tests.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated `README.md` (if you are adding a new model).
- [ ] I have updated `examples/README.md` (if you are adding a new example).
- [ ] I have updated `datasets/README.md` (if you are adding a new dataset).
