### PR TITLE
Fix EASE score function

### DIFF
--- a/cornac/models/ease/recom_ease.py
+++ b/cornac/models/ease/recom_ease.py
@@ -123,7 +123,7 @@ class EASE(Recommender, ANNMixin):
         if item_idx is None:
             return self.U[user_idx, :].dot(self.B)
 
-        return self.B[item_idx, :].dot(self.U[user_idx, :])
+        return self.U[user_idx, :].dot(self.B[:, item_idx])
 
     def get_vector_measure(self):
         """Getting a valid choice of vector measurement in ANNMixin._measures.


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
User-item scores should be computed using columns of B, not rows. B is not symmetric.

### Related Issues
<!--- If it fixes an open issue, please link to the issue here. -->
N/A

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have added tests.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated `README.md` (if you are adding a new model).
- [ ] I have updated `examples/README.md` (if you are adding a new example).
- [ ] I have updated `datasets/README.md` (if you are adding a new dataset).
