### PR TITLE
Ignore F824 lint check for serving app

### DIFF
--- a/cornac/serving/app.py
+++ b/cornac/serving/app.py
@@ -119,7 +119,7 @@ app = create_app()
 
 @app.route("/recommend", methods=["GET"])
 def recommend():
-    global model, train_set
+    global model, train_set # noqa: F824
 
     if model is None:
         return "Model is not yet loaded. Please try again later.", 400
@@ -187,7 +187,7 @@ def add_feedback():
 
 @app.route("/evaluate", methods=["POST"])
 def evaluate():
-    global model, train_set, metric_classnames
+    global model, train_set, metric_classnames # noqa: F824
 
     if model is None:
         return "Model is not yet loaded. Please try again later.", 400
@@ -241,7 +241,7 @@ def validate_query(query):
 
 
 def process_evaluation(test_set, query, exclude_unknowns):
-    global model, train_set
+    global model, train_set # noqa: F824
     
     rating_threshold = query.get("rating_threshold", 1.0)
     user_based = (


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
Flake8 raises errors for global variables declared in serving app without previously initialized. This is not an issue due to `_load_model()` always being called when starting an app. Thus, this ignores the lint checks.

### Related Issues
<!--- If it fixes an open issue, please link to the issue here. -->


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have added tests.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated `README.md` (if you are adding a new model).
- [ ] I have updated `examples/README.md` (if you are adding a new example).
- [ ] I have updated `datasets/README.md` (if you are adding a new dataset).
