### PR TITLE
Fix ZeroDivisionError on BPR by adding an epsilon

### DIFF
--- a/cornac/models/bpr/recom_bpr.pyx
+++ b/cornac/models/bpr/recom_bpr.pyx
@@ -196,7 +196,7 @@ class BPR(Recommender, ANNMixin):
                                                 user_ids, X.indices, neg_item_ids, X.indptr,
                                                 self.u_factors, self.i_factors, self.i_biases)
                 progress.set_postfix({
-                    "correct": "%.2f%%" % (100.0 * correct / (len(user_ids) - skipped)),
+                    "correct": "%.2f%%" % (100.0 * correct / (len(user_ids) - skipped + 1e-8)),
                     "skipped": "%.2f%%" % (100.0 * skipped / len(user_ids))
                 })
 

--- a/cornac/models/bpr/recom_wbpr.pyx
+++ b/cornac/models/bpr/recom_wbpr.pyx
@@ -135,7 +135,7 @@ class WBPR(BPR):
                                                  user_ids, X.indices, X.indices, X.indptr,
                                                  self.u_factors, self.i_factors, self.i_biases)
                 progress.set_postfix({
-                    "correct": "%.2f%%" % (100.0 * correct / (len(user_ids) - skipped)),
+                    "correct": "%.2f%%" % (100.0 * correct / (len(user_ids) - skipped + 1e-8)),
                     "skipped": "%.2f%%" % (100.0 * skipped / len(user_ids))
                 })
         if self.verbose:


### PR DESCRIPTION
### Description
I've added the small epsilon value (1e-8) in the `(100.0 * correct / (len(user_ids) - skipped)` calculation to avoid zero division error when fitting the model. This change is applied to both BPR and WBPR.


### Related Issues
#675


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have added tests.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated `README.md` (if you are adding a new model).
- [ ] I have updated `examples/README.md` (if you are adding a new example).
- [ ] I have updated `datasets/README.md` (if you are adding a new dataset).
