### PR TITLE
docs: fix typo in build_ext command

### DIFF
--- a/docs/source/user/iamaresearcher.rst
+++ b/docs/source/user/iamaresearcher.rst
@@ -770,7 +770,7 @@ run the following command:
 
 .. code-block:: bash
 
-    python setup.py build_ext —inplace
+    python setup.py build_ext --inplace
 
 This will generate C++ files from Cython files, compile the C++ files, and place the compiled binary files in the necessary folders.
 


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
Fixed the em-dash typo in the installation guide for build_ext command to prevent terminal errors

### Related Issues
<!--- If it fixes an open issue, please link to the issue here. -->


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have added tests.
- [x] I have updated the documentation accordingly.
- [ ] I have updated `README.md` (if you are adding a new model).
- [ ] I have updated `examples/README.md` (if you are adding a new example).
- [ ] I have updated `datasets/README.md` (if you are adding a new dataset).
