### PR TITLE
data: migrate movielens dataset to new domain

### DIFF
--- a/cornac/datasets/movielens.py
+++ b/cornac/datasets/movielens.py
@@ -28,28 +28,28 @@ VALID_DATA_FORMATS = ["UIR", "UIRT"]
 MovieLens = namedtuple("MovieLens", ["url", "unzip", "path", "sep", "skip"])
 ML_DATASETS = {
     "100K": MovieLens(
-        "http://files.grouplens.org/datasets/movielens/ml-100k/u.data",
+        "https://static.preferred.ai/cornac/datasets/movielens/ml-100k/u.data",
         False,
         "ml-100k/u.data",
         "\t",
         0,
     ),
     "1M": MovieLens(
-        "http://files.grouplens.org/datasets/movielens/ml-1m.zip",
+        "https://static.preferred.ai/cornac/datasets/movielens/ml-1m.zip",
         True,
         "ml-1m/ratings.dat",
         "::",
         0,
     ),
     "10M": MovieLens(
-        "http://files.grouplens.org/datasets/movielens/ml-10m.zip",
+        "https://static.preferred.ai/cornac/datasets/movielens/ml-10m.zip",
         True,
         "ml-10M100K/ratings.dat",
         "::",
         0,
     ),
     "20M": MovieLens(
-        "http://files.grouplens.org/datasets/movielens/ml-20m.zip",
+        "https://static.preferred.ai/cornac/datasets/movielens/ml-20m.zip",
         True,
         "ml-20m/ratings.csv",
         ",",

--- a/examples/given_data.py
+++ b/examples/given_data.py
@@ -24,10 +24,10 @@ from cornac.utils import cache
 # Download MovieLens 100K provided train and test sets
 reader = Reader()
 train_data = reader.read(
-    cache(url="http://files.grouplens.org/datasets/movielens/ml-100k/u1.base")
+    cache(url="https://static.preferred.ai/cornac/datasets/movielens/ml-100k/u1.base")
 )
 test_data = reader.read(
-    cache(url="http://files.grouplens.org/datasets/movielens/ml-100k/u1.test")
+    cache(url="https://static.preferred.ai/cornac/datasets/movielens/ml-100k/u1.test")
 )
 
 # Instantiate a Base evaluation method using the provided train and test sets


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
The `http://files.grouplens.org/datasets/movielens` domain for `movielens` dataset is down, so we create backup of the data to `static.preferred.ai`.

### Related Issues
<!--- If it fixes an open issue, please link to the issue here. -->


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have added tests.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated `README.md` (if you are adding a new model).
- [ ] I have updated `examples/README.md` (if you are adding a new example).
- [ ] I have updated `datasets/README.md` (if you are adding a new dataset).
