### PR TITLE
Support hyper-parameter search for next-item recommenders (#643)

### DIFF
--- a/cornac/eval_methods/next_item_evaluation.py
+++ b/cornac/eval_methods/next_item_evaluation.py
@@ -335,7 +335,10 @@ class NextItemEvaluation(BaseMethod):
         -------
         res: :obj:`cornac.experiment.Result`
         """
-        if not isinstance(model, NextItemRecommender):
+        base_model = getattr(model, "model", None)
+        if not isinstance(model, NextItemRecommender) and not isinstance(
+            base_model, NextItemRecommender
+        ):
             raise ValueError("model must be a NextItemRecommender but '%s' is provided" % type(model))
 
         if self.train_set is None:

--- a/cornac/hyperopt.py
+++ b/cornac/hyperopt.py
@@ -17,9 +17,10 @@
 import numpy as np
 from itertools import product
 
-from .models import Recommender
+from .models import Recommender, NextItemRecommender
 from .metrics import RatingMetric, RankingMetric
 from .eval_methods import rating_eval, ranking_eval
+from .eval_methods.next_item_evaluation import ranking_eval as next_item_ranking_eval
 from .utils import get_rng
 
 
@@ -147,6 +148,16 @@ class BaseSearch(Recommender):
 
             if isinstance(self.metric, RatingMetric):
                 score = rating_eval(model, [self.metric], val_set)[0][0]
+            elif isinstance(model, NextItemRecommender):
+                score = next_item_ranking_eval(
+                    model,
+                    [self.metric],
+                    train_set,
+                    val_set,
+                    exclude_unknowns=self.eval_method.exclude_unknowns,
+                    mode=self.eval_method.mode,
+                    verbose=False,
+                )[0][0]
             else:
                 score = ranking_eval(
                     model,
@@ -171,9 +182,17 @@ class BaseSearch(Recommender):
 
         return self
 
-    def score(self, user_idx, item_idx=None):
+    def transform(self, test_set):
+        """Delegate test-set transformation to the best searched model."""
+        return self.best_model.transform(test_set)
+
+    def score(self, user_idx, *args, **kwargs):
         """Scoring using the best searched model"""
-        return self.best_model.score(user_idx, item_idx)
+        return self.best_model.score(user_idx, *args, **kwargs)
+
+    def rank(self, user_idx, item_indices=None, k=-1, **kwargs):
+        """Ranking using the best searched model"""
+        return self.best_model.rank(user_idx, item_indices, k, **kwargs)
 
 
 class GridSearch(BaseSearch):

--- a/cornac/hyperopt.py
+++ b/cornac/hyperopt.py
@@ -282,7 +282,7 @@ class RandomSearch(BaseSearch):
         """Generate searching points"""
         param_set = []
         keys = [d.name for d in self.space]
-        rng = get_rng(self.model.seed)
+        rng = get_rng(getattr(self.model, "seed", None))
         while len(param_set) < self.n_trails:
             params = [d._sample(rng) for d in self.space]
             param_set.append(dict(zip(keys, params)))

--- a/docs/source/user/iamadeveloper.rst
+++ b/docs/source/user/iamadeveloper.rst
@@ -111,6 +111,10 @@ this, we can use the `cornac.hyperopt` module to perform the searches.
 As shown in the above code, we have defined two methods for hyper-parameter search,
 ``GridSearch`` and ``RandomSearch``.
 
+The same search classes support next-item recommenders when paired with
+``NextItemEvaluation``. In both cases, the evaluation method must include a
+validation split, which is used to select the best parameter settings.
+
 +------------------------------------------+---------------------------------------------+
 | Grid Search                              | Random Search                               |
 +==========================================+=============================================+

--- a/tests/cornac/test_hyperopt.py
+++ b/tests/cornac/test_hyperopt.py
@@ -27,15 +27,6 @@ from cornac.hyperopt import GridSearch, RandomSearch
 from cornac import Experiment
 
 
-class SeededSPop(SPop):
-    def __init__(self, name="SPop", use_session_popularity=True, seed=123):
-        super().__init__(
-            name=name,
-            use_session_popularity=use_session_popularity,
-        )
-        self.seed = seed
-
-
 class TestCommon(unittest.TestCase):
     
     def setUp(self):
@@ -91,7 +82,7 @@ class TestCommon(unittest.TestCase):
         )
         metric = HitRatio(k=5)
         rs_spop = RandomSearch(
-            model=SeededSPop(),
+            model=SPop(),
             space=[Discrete("use_session_popularity", [False, True])],
             metric=metric,
             eval_method=eval_method,

--- a/tests/cornac/test_hyperopt.py
+++ b/tests/cornac/test_hyperopt.py
@@ -19,12 +19,21 @@ import numpy as np
 import numpy.testing as npt
 
 from cornac.data import Reader
-from cornac.models import MF, BPR
-from cornac.metrics import RMSE, AUC
-from cornac.eval_methods import RatioSplit
+from cornac.models import MF, BPR, SPop
+from cornac.metrics import RMSE, AUC, HitRatio
+from cornac.eval_methods import RatioSplit, NextItemEvaluation
 from cornac.hyperopt import Discrete, Continuous
 from cornac.hyperopt import GridSearch, RandomSearch
 from cornac import Experiment
+
+
+class SeededSPop(SPop):
+    def __init__(self, name="SPop", use_session_popularity=True, seed=123):
+        super().__init__(
+            name=name,
+            use_session_popularity=use_session_popularity,
+        )
+        self.seed = seed
 
 
 class TestCommon(unittest.TestCase):
@@ -69,6 +78,67 @@ class TestCommon(unittest.TestCase):
             metrics=[metric],
             user_based=False,
         ).run()
+
+    def test_random_search_next_item_recommender(self):
+        data = Reader().read("./tests/sequence.txt", fmt="USIT", sep=" ")
+        eval_method = NextItemEvaluation.from_splits(
+            train_data=data[:35],
+            val_data=data[35:50],
+            test_data=data[50:],
+            fmt="USIT",
+            exclude_unknowns=False,
+            mode="next",
+        )
+        metric = HitRatio(k=5)
+        rs_spop = RandomSearch(
+            model=SeededSPop(),
+            space=[Discrete("use_session_popularity", [False, True])],
+            metric=metric,
+            eval_method=eval_method,
+            n_trails=2,
+        )
+
+        test_result, _ = eval_method.evaluate(
+            model=rs_spop,
+            metrics=[metric],
+            user_based=False,
+            show_validation=False,
+        )
+
+        self.assertIsNotNone(rs_spop.best_model)
+        self.assertEqual(rs_spop.best_params, {"use_session_popularity": False})
+        self.assertAlmostEqual(rs_spop.best_score, 11 / 12)
+        self.assertTrue(np.isfinite(test_result.metric_avg_results["HitRatio@5"]))
+
+    def test_grid_search_next_item_recommender(self):
+        data = Reader().read("./tests/sequence.txt", fmt="USIT", sep=" ")
+        eval_method = NextItemEvaluation.from_splits(
+            train_data=data[:35],
+            val_data=data[35:50],
+            test_data=data[50:],
+            fmt="USIT",
+            exclude_unknowns=False,
+            mode="next",
+        )
+        metric = HitRatio(k=5)
+        gs_spop = GridSearch(
+            model=SPop(),
+            space=[Discrete("use_session_popularity", [False, True])],
+            metric=metric,
+            eval_method=eval_method,
+        )
+
+        test_result, _ = eval_method.evaluate(
+            model=gs_spop,
+            metrics=[metric],
+            user_based=False,
+            show_validation=False,
+        )
+
+        self.assertIsNotNone(gs_spop.best_model)
+        self.assertEqual(gs_spop.best_params, {"use_session_popularity": False})
+        self.assertAlmostEqual(gs_spop.best_score, 11 / 12)
+        self.assertTrue(np.isfinite(test_result.metric_avg_results["HitRatio@5"]))
 
 
 if __name__ == "__main__":

--- a/tests/cornac/test_hyperopt.py
+++ b/tests/cornac/test_hyperopt.py
@@ -81,8 +81,10 @@ class TestCommon(unittest.TestCase):
             mode="next",
         )
         metric = HitRatio(k=5)
+        spop = SPop()
+        spop.seed = 123  # for reproducible RandomSearch sampling
         rs_spop = RandomSearch(
-            model=SPop(),
+            model=spop,
             space=[Discrete("use_session_popularity", [False, True])],
             metric=metric,
             eval_method=eval_method,


### PR DESCRIPTION
### Description

`GridSearch` and `RandomSearch` (`cornac.hyperopt`) could not be used to tune `NextItemRecommender` models evaluated with `NextItemEvaluation`. Two issues blocked it:

1. **The search wrapper was rejected by the evaluator.** `NextItemEvaluation.evaluate()` requires its `model` to be a `NextItemRecommender`, but a `GridSearch`/`RandomSearch` object is a `Recommender` wrapper, not a `NextItemRecommender`. It raised:

   ```
   ValueError: model must be a NextItemRecommender but '<class 'cornac.hyperopt.RandomSearch'>' is provided
   ```

2. **The search loop scored next-item models with the wrong evaluator.** Inside `BaseSearch.fit`, ranking metrics fell through to the standard `ranking_eval`, whose `rank()`/`score()` path is incompatible with the session-based signature `score(user_idx, history_items, ...)`:

   ```
   TypeError: SPop.score() missing 1 required positional argument: 'history_items'
   ```

**Fix:**

- `NextItemEvaluation.evaluate()` now also accepts a search wrapper whose `.model` is a `NextItemRecommender`.
- `BaseSearch.fit()` routes `NextItemRecommender` candidates through `next_item_evaluation.ranking_eval`, passing the eval method's `exclude_unknowns` and `mode`.
- `BaseSearch` delegates `transform`/`score`/`rank` to the selected `best_model`, so the fitted wrapper evaluates transparently on the test set.

This is additive — the existing rating/standard-ranking search paths are unchanged (verified by the pre-existing `test_grid_search`/`test_random_search`).

### Related Issues

Fixes #643.

### Checklist:

- [x] I have added tests.
- [x] I have updated the documentation accordingly.
- [ ] I have updated `README.md` (if you are adding a new model).
- [ ] I have updated `examples/README.md` (if you are adding a new example).
- [ ] I have updated `datasets/README.md` (if you are adding a new dataset).
