### PR TITLE
Automate ReadTheDocs model page updates

### DIFF
--- a/.github/workflows/update-model-table.yml
+++ b/.github/workflows/update-model-table.yml
@@ -1,0 +1,39 @@
+name: update-model-table
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - 'README.md'
+      - 'docs/generate_model_js.py'
+  release:
+    types: [published]
+
+jobs:
+  update-model-table:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: Run model table generation script
+        working-directory: docs
+        run: python generate_model_js.py
+
+      - name: Commit and push if changed
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add docs/source/_static/models/data.js
+          if git diff --cached --quiet; then
+            echo "No changes to commit"
+          else
+            git commit -m "docs: auto-update model table [skip ci]"
+            git push
+          fi

--- a/.github/workflows/update-model-table.yml
+++ b/.github/workflows/update-model-table.yml
@@ -9,6 +9,10 @@ on:
   release:
     types: [published]
 
+concurrency:
+  group: update-model-table
+  cancel-in-progress: true
+
 jobs:
   update-model-table:
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Description
Adds a GitHub Actions workflow (`.github/workflows/update-model-table.yml`) that automatically regenerates the models table (`docs/source/_static/models/data.js`) by running `docs/generate_model_js.py` whenever relevant files change. The workflow triggers on pushes to `master` that touch `README.md` or the generation script, and on published releases. It only commits if the output actually changed, using `[skip ci]` to avoid recursive runs.

The page is viewable at https://cornac.readthedocs.io/en/latest/models/

This removes the need for contributors to manually run the script and push the generated file after each change.

### Related Issues
Fixes #647

### Checklist:
- [ ] I have added tests.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated `README.md` (if you are adding a new model).
- [ ] I have updated `examples/README.md` (if you are adding a new example).
- [ ] I have updated `datasets/README.md` (if you are adding a new dataset).