### PR TITLE
Update Flask serving command and fix typo in app.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ After that, the model can be deployed easily by running Cornac serving app as fo
 ```bash
 $ MODEL_PATH='save_dir/BPR' \
   MODEL_CLASS='cornac.models.BPR' \
-  flask --app cornac.serving.app run --host localhost --port 8080
+  flask --app cornac.serving.app run --host localhost --port 8080  # requires Flask>=2.2 (older Flask: FLASK_APP='cornac.serving.app' flask run ...)
 
 # Running on http://localhost:8080
 ```

--- a/README.md
+++ b/README.md
@@ -110,10 +110,9 @@ bpr.save("save_dir", save_trainset=True)
 ```
 After that, the model can be deployed easily by running Cornac serving app as follows:
 ```bash
-$ FLASK_APP='cornac.serving.app' \
-  MODEL_PATH='save_dir/BPR' \
+$ MODEL_PATH='save_dir/BPR' \
   MODEL_CLASS='cornac.models.BPR' \
-  flask run --host localhost --port 8080
+  flask --app cornac.serving.app run --host localhost --port 8080
 
 # Running on http://localhost:8080
 ```

--- a/cornac/serving/app.py
+++ b/cornac/serving/app.py
@@ -91,8 +91,8 @@ def _load_model(instance_path):
         "Model loaded"
         if train_set is None
         else """
-        Model and train set loaded. Remove seen items by adding 
-        remove_seen=true' query param to the recommend endpoint.
+        Model and train set loaded. Remove seen items by adding
+        'remove_seen=true' query param to the recommend endpoint.
         """
     )
 

--- a/docs/source/user/iamadeveloper.rst
+++ b/docs/source/user/iamadeveloper.rst
@@ -506,10 +506,9 @@ command:
 
 .. code-block:: bash
     
-    FLASK_APP='cornac.serving.app' \
     MODEL_PATH='save_dir/BPR' \
     MODEL_CLASS='cornac.models.BPR' \
-    flask run --host localhost --port 8080
+    flask --app cornac.serving.app run --host localhost --port 8080  # requires Flask>=2.2
 
 This will serve an API for the BPR model saved in the directory ``save_dir/BPR``.
 The API will be launched at `localhost:8080` and following output will be shown:


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
Updates the Flask serving command in the README to use Flask's newer --app flag instead of the deprecated FLASK_APP environment variable. Also fixes a typo in app.py where a single quote was missing before remove_seen=true in the log message, and removes trailing whitespace in the same string.
<!--- Why is this change required? What problem does it solve? -->


### Related Issues
<!--- If it fixes an open issue, please link to the issue here. -->
N/A

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have added tests.
- [X] I have updated the documentation accordingly.
- [ ] I have updated `README.md` (if you are adding a new model).
- [ ] I have updated `examples/README.md` (if you are adding a new example).
- [ ] I have updated `datasets/README.md` (if you are adding a new dataset).
