### PR TITLE
Add `use_biases` to SASRec

### DIFF
--- a/cornac/models/sasrec/recom_sasrec.py
+++ b/cornac/models/sasrec/recom_sasrec.py
@@ -91,6 +91,10 @@ class SASRec(NextItemRecommender):
     use_pos_emb: bool, optional, default: True
         Whether to add learned positional embeddings.
 
+    use_biases: bool, optional, default: False
+        Whether to add a learned per-item scalar bias to the scores. Set to
+        False for the canonical SASRec (no per-item bias term).
+
     model_selection: str, optional, default: 'last'
         One of 'last' or 'best'. When 'best', the model with the highest
         validation score (evaluated every ``val_eval_every`` epochs) is
@@ -136,6 +140,7 @@ class SASRec(NextItemRecommender):
         elu_param=0.5,
         device="cpu",
         use_pos_emb=True,
+        use_biases=False,
         trainable=True,
         verbose=False,
         seed=None,
@@ -169,6 +174,7 @@ class SASRec(NextItemRecommender):
         self.elu_param = elu_param
         self.device = device
         self.use_pos_emb = use_pos_emb
+        self.use_biases = use_biases
         self.seed = seed
         self.rng = get_rng(seed)
         self.model_selection = model_selection
@@ -183,8 +189,8 @@ class SASRec(NextItemRecommender):
 
         import torch
 
-        from .sasrec import SASRecModel
         from ..seq_utils.losses import get_loss_function
+        from .sasrec import SASRecModel
 
         torch.manual_seed(self.seed if self.seed is not None else 0)
 
@@ -196,6 +202,7 @@ class SASRec(NextItemRecommender):
             n_layers=self.num_blocks,
             n_heads=self.num_heads,
             use_pos_emb=self.use_pos_emb,
+            use_biases=self.use_biases,
             dropout=self.dropout,
             pad_idx=self.pad_idx,
             device=self.device,


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
The current `SASRecModel` backend has a `use_bias` option, but it isn't exposed to `SASRec` recommender class. Tuning results from https://github.com/PreferredAI/cornac/blob/master/cornac/models/tiger/README.md#best-tiger-configs-vs-tuned-sasrec-beauty showed that `use_bias=False` yields better performance, so we are defaulting it to `False`.

### Related Issues
<!--- If it fixes an open issue, please link to the issue here. -->


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have added tests.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated `README.md` (if you are adding a new model).
- [ ] I have updated `examples/README.md` (if you are adding a new example).
- [ ] I have updated `datasets/README.md` (if you are adding a new dataset).
